### PR TITLE
the index label of det and ets is now "variable"

### DIFF
--- a/src/swissclim_evaluations/metrics/deterministic.py
+++ b/src/swissclim_evaluations/metrics/deterministic.py
@@ -442,8 +442,8 @@ def run(
             ensemble=ens_token,
             ext="csv",
         )
-        regular_metrics.to_csv(out_csv)
-        standardized_metrics.to_csv(out_csv_std)
+        regular_metrics.to_csv(out_csv, index_label="variable")
+        standardized_metrics.to_csv(out_csv_std, index_label="variable")
         print(f"[deterministic] saved {out_csv}")
         print(f"[deterministic] saved {out_csv_std}")
 
@@ -569,8 +569,8 @@ def run(
                 ensemble=token_m,
                 ext="csv",
             )
-            reg_m.to_csv(out_csv_m)
-            std_m.to_csv(out_csv_m_std)
+            reg_m.to_csv(out_csv_m, index_label="variable")
+            std_m.to_csv(out_csv_m_std, index_label="variable")
             print(f"[deterministic] saved {out_csv_m}")
             print(f"[deterministic] saved {out_csv_m_std}")
             pooled_metrics.append(reg_m)
@@ -634,7 +634,7 @@ def run(
                     ensemble="enspooled",
                     ext="csv",
                 )
-                pooled_df.to_csv(out_csv_pool)
+                pooled_df.to_csv(out_csv_pool, index_label="variable")
                 print(f"[deterministic] saved {out_csv_pool}")
 
         # Console previews for members mode

--- a/src/swissclim_evaluations/metrics/ets.py
+++ b/src/swissclim_evaluations/metrics/ets.py
@@ -174,7 +174,7 @@ def run(
             ext="csv",
         )
         if members_indices is None:
-            df.to_csv(out_csv)
+            df.to_csv(out_csv, index_label="variable")
             print(f"[ets] saved {out_csv}")
 
             if report_per_level:
@@ -212,7 +212,7 @@ def run(
                     ensemble=token_m,
                     ext="csv",
                 )
-                df_m.to_csv(out_csv_m)
+                df_m.to_csv(out_csv_m, index_label="variable")
                 print(f"[ets] saved {out_csv_m}")
                 per_member_dfs.append(df_m)
 
@@ -247,5 +247,5 @@ def run(
                         ensemble="enspooled",
                         ext="csv",
                     )
-                    pooled_df.to_csv(out_pool)
+                    pooled_df.to_csv(out_pool, index_label="variable")
                     print(f"[ets] saved {out_pool}")


### PR DESCRIPTION
The deterministic and the ETS module were missing a label for the index column. That's why there was unnamed-0 in the csv output. All labels are now reading "variable" instead.