### PR TITLE
feat: add multivariate bivariate histogram module

### DIFF
--- a/config/debug_run.yaml
+++ b/config/debug_run.yaml
@@ -50,6 +50,7 @@ modules:
   deterministic: true
   ets: true
   probabilistic: false
+  multivariate: false
 
 metrics:
   deterministic:

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -375,7 +375,12 @@ metrics:
       - ["vertical_velocity", "temperature"]
       # Uncomment the line below to enable geostrophic-balance overlay (★).
       # Requires geopotential_height_gradient and wind_speed in derived_variables.
-      # - ["geopotential_height_gradient", "wind_speed"]
+    # Coriolis parameter f [s⁻¹] for the geostrophic reference line overlay.
+    # f = 2 * Ω * sin(φ), where Ω = 7.2921e-5 rad s⁻¹.
+    # Generic mid-latitude default: 1.0e-4 s⁻¹  (≈ 43 °N)
+    # Central Europe (~50 °N):      1.12e-4 s⁻¹
+    # Switzerland / Alps (~47 °N):  1.07e-4 s⁻¹
+    coriolis_parameter: 1.0e-4
 
 performance:
   # Dask scheduler choice.

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -245,6 +245,16 @@ derived_variables:
     kind: wind_speed
     u: u_component_of_wind
     v: v_component_of_wind
+  # geopotential_height_gradient — |∇Z|, m m⁻¹.  Enables the geostrophic-balance
+  # physical-constraint overlay in bivariate histograms.  Two-step derivation:
+  # first convert raw geopotential (m² s⁻²) → height Z (m), then take |∇Z|.
+  # Uncomment both blocks below (and add 'geopotential' to the variables list).
+  # geopotential_height:
+  #   kind: geopotential_height
+  #   source: geopotential          # raw geopotential variable (m² s⁻²)
+  # geopotential_height_gradient:
+  #   kind: geopotential_height_gradient
+  #   source: geopotential_height   # output of the block above
 
 modules:
   # Toggle individual modules on/off. The CLI runs based on these flags only.

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -132,6 +132,7 @@ selection:
     deterministic: mean      # mean | pooled | members
     ets: mean                # mean | pooled | members
     probabilistic: prob      # prob (only valid choice)
+    multivariate: mean       # mean | pooled | members
     # Validation will raise an error if an unsupported mode is specified (e.g. maps: pooled).
 
   # If true, enables a scan for NaN values in the data (reported as warnings).
@@ -255,6 +256,7 @@ modules:
   deterministic: true        # Deterministic metrics (MAE, RMSE, etc.) incl. standardized variants
   ets: true                  # Equitable Threat Score across quantile thresholds
   probabilistic: true        # Combined probabilistic (xarray CRPS/PIT + WBX SSR/CRPS)
+  multivariate: true         # Multivariate metrics (e.g. Bivariate Histograms)
 
 metrics:
   # Deterministic metrics configuration. If lists are omitted, a default set is computed.
@@ -338,6 +340,18 @@ metrics:
     # Per-level reporting for 3D variables is enabled by default.
     # If true, compute and report CRPS/SSR summaries per pressure level (for 3D variables).
     report_per_level: true
+
+  # Multivariate metrics configuration.
+  multivariate:
+    # Bivariate histograms configuration
+    # List of variable pairs to generate 2D histograms and density plots for.
+    bivariate_pairs:
+      - ["10m_u_component_of_wind", "10m_v_component_of_wind"]
+      - ["u_component_of_wind", "v_component_of_wind"]
+      - ["temperature", "specific_humidity"]
+      - ["geopotential", "temperature"]
+      - ["total_precipitation", "total_column_water_vapour"]
+      - ["vertical_velocity", "temperature"]
 
 performance:
   # Dask scheduler choice.

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -258,14 +258,14 @@ derived_variables:
 
 modules:
   # Toggle individual modules on/off. The CLI runs based on these flags only.
-  maps: false                 # Global and per-level maps (Cartopy)
-  histograms: false           # Distributions by latitude bands (2D + optional per-level 3D variables)
-  wd_kde: false               # KDE by latitude band on standardized fields (2D + optional per-level 3D); reports mean Wasserstein
-  energy_spectra: false       # Zonal energy spectra + LSD table
-  vertical_profiles: false    # Normalized MAE (NMAE) vertical profiles per latitude band (3D; artifact-only)
-  deterministic: false        # Deterministic metrics (MAE, RMSE, etc.) incl. standardized variants
-  ets: false                  # Equitable Threat Score across quantile thresholds
-  probabilistic: false        # Combined probabilistic (xarray CRPS/PIT + WBX SSR/CRPS)
+  maps: true                  # Global and per-level maps (Cartopy)
+  histograms: true            # Distributions by latitude bands (2D + optional per-level 3D variables)
+  wd_kde: true                # KDE by latitude band on standardized fields (2D + optional per-level 3D); reports mean Wasserstein
+  energy_spectra: true        # Zonal energy spectra + LSD table
+  vertical_profiles: true     # Normalized MAE (NMAE) vertical profiles per latitude band (3D; artifact-only)
+  deterministic: true         # Deterministic metrics (MAE, RMSE, etc.) incl. standardized variants
+  ets: true                   # Equitable Threat Score across quantile thresholds
+  probabilistic: true         # Combined probabilistic (xarray CRPS/PIT + WBX SSR/CRPS)
   multivariate: true         # Multivariate metrics (e.g. Bivariate Histograms)
 
 metrics:

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -248,14 +248,14 @@ derived_variables:
 
 modules:
   # Toggle individual modules on/off. The CLI runs based on these flags only.
-  maps: true                 # Global and per-level maps (Cartopy)
-  histograms: true           # Distributions by latitude bands (2D + optional per-level 3D variables)
-  wd_kde: true               # KDE by latitude band on standardized fields (2D + optional per-level 3D); reports mean Wasserstein
-  energy_spectra: true       # Zonal energy spectra + LSD table
-  vertical_profiles: true    # Normalized MAE (NMAE) vertical profiles per latitude band (3D; artifact-only)
-  deterministic: true        # Deterministic metrics (MAE, RMSE, etc.) incl. standardized variants
-  ets: true                  # Equitable Threat Score across quantile thresholds
-  probabilistic: true        # Combined probabilistic (xarray CRPS/PIT + WBX SSR/CRPS)
+  maps: false                 # Global and per-level maps (Cartopy)
+  histograms: false           # Distributions by latitude bands (2D + optional per-level 3D variables)
+  wd_kde: false               # KDE by latitude band on standardized fields (2D + optional per-level 3D); reports mean Wasserstein
+  energy_spectra: false       # Zonal energy spectra + LSD table
+  vertical_profiles: false    # Normalized MAE (NMAE) vertical profiles per latitude band (3D; artifact-only)
+  deterministic: false        # Deterministic metrics (MAE, RMSE, etc.) incl. standardized variants
+  ets: false                  # Equitable Threat Score across quantile thresholds
+  probabilistic: false        # Combined probabilistic (xarray CRPS/PIT + WBX SSR/CRPS)
   multivariate: true         # Multivariate metrics (e.g. Bivariate Histograms)
 
 metrics:
@@ -343,15 +343,29 @@ metrics:
 
   # Multivariate metrics configuration.
   multivariate:
-    # Bivariate histograms configuration
-    # List of variable pairs to generate 2D histograms and density plots for.
+    # Bivariate histograms: list of [var_x, var_y] pairs to compare as 2-D
+    # joint distributions.  Pairs marked with ★ receive automatic physical-
+    # constraint overlays (Clausius–Clapeyron saturation curve, geostrophic
+    # balance line) drawn on top of the histogram panels.
+    #
+    #  ★ temperature × specific_humidity
+    #       Clausius–Clapeyron saturation curve (Bolton 1980) per pressure level;
+    #       supersaturated and q < 0 regions are shaded.
+    #
+    #  ★ geopotential_height_gradient × wind_speed
+    #       Geostrophic-balance reference line and wind_speed ≥ 0 bound.
+    #       Requires derived_variables: geopotential_height_gradient and wind_speed.
+    #       See the derived_variables block above for how to configure them.
     bivariate_pairs:
       - ["10m_u_component_of_wind", "10m_v_component_of_wind"]
       - ["u_component_of_wind", "v_component_of_wind"]
-      - ["temperature", "specific_humidity"]
+      - ["temperature", "specific_humidity"]        # ★ physical constraints
       - ["geopotential", "temperature"]
       - ["total_precipitation", "total_column_water_vapour"]
       - ["vertical_velocity", "temperature"]
+      # Uncomment the line below to enable geostrophic-balance overlay (★).
+      # Requires geopotential_height_gradient and wind_speed in derived_variables.
+      # - ["geopotential_height_gradient", "wind_speed"]
 
 performance:
   # Dask scheduler choice.

--- a/config/intercomparison.yaml
+++ b/config/intercomparison.yaml
@@ -4,13 +4,7 @@
 # - models: list of per-model output directories to compare
 # - labels: optional human-friendly labels (must match models length); if omitted, folder names are used
 # - output_root: where to write combined artifacts (PNG/CSV)
-# - modules: subset of modules to run: spectra, hist, kde, maps, metrics, ets, prob, vprof
-#            spectra includes per-lead delta spectrogram compare when
-#            `energy_spectra_per_lead_*_bundle*.npz` artifacts are available
-#            kde includes ridgeline evolution compare when
-#            `wd_kde_evolve_*_ridgeline_data*.npz` artifacts are available
-#            probabilistic temporal combines `crps_line_*_by_lead*.csv` and
-#            `ssr_line_*_by_lead*.csv` (including optional `_level<lvl>` variants)
+# - modules: subset of modules to run: spectra, hist, kde, maps, metrics, ets, prob, vprof, multivariate
 # - max_map_panels: limit number of map panels rendered
 # - max_crps_map_panels: limit CRPS map panels in probabilistic section
 
@@ -24,7 +18,7 @@ labels:
 
 output_root: output/intercomparison
 
-modules: [maps, hist, kde, spectra, vprof, metrics, ets, prob]
+modules: [maps, hist, kde, spectra, vprof, metrics, ets, prob, multivariate]
 
 max_map_panels: 4
 max_crps_map_panels: 4

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -122,6 +122,37 @@ ets_line_2m_temperature_ensmean.png
 ets_line_2m_temperature_data_ensmean.npz
 ```
 
+### Multivariate Metrics
+
+Bivariate density plots (histograms) are generated for specified variable pairs (e.g., u10m vs v10m). These plots visualize the joint distribution of two variables, comparing the prediction (grey contours) against the reference (filled plasma contours).
+
+**Recommended Bivariate Pairs:**
+
+To evaluate physical consistency, we recommend plotting pairs that capture fundamental relationships:
+
+1.  **Surface Dynamics (Wind Vector):** `10m_u_component_of_wind` vs `10m_v_component_of_wind`.
+    *   *Suggested Level:* Surface (10m).
+    *   *Why:* Visualizes the surface circulation and wind variability. Biases in the spread indicate errors in surface friction or storm intensity.
+2.  **Upper-level Dynamics (Wind Vector):** `u_component_of_wind` vs `v_component_of_wind`.
+    *   *Suggested Level:* 250 hPa (Jet Stream).
+    *   *Why:* Captures the jet stream structure and synoptic variability. Biases in the spread indicate errors in the storm track or mean flow.
+3.  **Thermodynamics (Clausius-Clapeyron):** `temperature` vs `specific_humidity`.
+    *   *Suggested Level:* 850 hPa (Lower Troposphere).
+    *   *Why:* Warmer air holds more moisture. The distribution should show a sharp cutoff at the saturation curve, which follows the Clausius-Clapeyron relation. Points beyond this curve indicate unphysical supersaturation.
+4.  **Hydrostatics:** `geopotential` vs `temperature`.
+    *   *Suggested Level:* 500 hPa (Mid-troposphere).
+    *   *Why:* Relates to hydrostatic balance. Low geopotential heights (troughs) are typically associated with cold air (cold-core cyclones).
+5.  **Precipitation Physics:** `total_precipitation` vs `total_column_water_vapour`.
+    *   *Suggested Level:* Surface / Column-integrated.
+    *   *Why:* Checks precipitation efficiency. Deep convection requires a moist column. Look for a "hockey stick" relationship where precipitation increases rapidly above a critical $TCWV$ threshold (Bretherton et al. 2004).
+6.  **Vertical Motion:** `vertical_velocity` vs `temperature`.
+    *   *Suggested Level:* 500 hPa (Mid-troposphere).
+    *   *Why:* Evaluates convective processes. Upward motion (negative $\omega$) is often driven by buoyancy (warm anomalies) in convective systems. Look for asymmetries between strong narrow updrafts and broad downdrafts.
+
+Outputs:
+- `bivariate_hist_<var1>_<var2>.npz`: Saved histogram counts and bin edges.
+- `bivariate_<var1>_<var2>.png`: The generated density plot comparing the current model (Prediction) against the reference.
+
 ### Energy Spectra Analysis
 
 Per-variable (and per-level) energy spectra are computed retaining time structure; the Log Spectral Distance (LSD)
@@ -189,6 +220,13 @@ map_10m_u_component_of_wind_init2023010200-2023010412_ens0.png   # member 0
 map_temperature_500_init2023010200-2023010412_ensmean.png        # mean reduction
 map_10m_u_component_of_wind_init2023010200-2023010412_ens3.npz   # NPZ export (output_mode=npz/both)
 ```
+
+### Bivariate Histograms
+
+Outputs (standardized naming):
+
+- Plot: `multivariate/bivariate_<var1>_<var2>_ens*.png`
+- Data (NPZ): `multivariate/bivariate_hist_<var1>_<var2>_ens*.npz`
 
 **3D variables and multi-lead NPZ files**: For 3D atmospheric variables evaluated with more than one lead time, the NPZ files are saved **per pressure level** (one file per level) with the full lead-time stack preserved:
 

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -124,14 +124,14 @@ ets_line_2m_temperature_data_ensmean.npz
 
 ### Multivariate Metrics (Bivariate Histograms)
 
-Bivariate density plots (histograms) are generated for specified variable pairs (e.g., u10m vs v10m). These plots visualize the joint distribution of two variables, comparing the prediction (grey contours) against the reference (filled plasma contours). Physical constraint overlays (e.g. Clausius–Clapeyron saturation curve, geostrophic balance line) are drawn automatically at the appropriate pressure level when the pair is recognised.
+Bivariate density plots (histograms) are generated for specified variable pairs (e.g., u10m vs v10m). These plots visualize the joint distribution of two variables, comparing the prediction (grey contours) against the reference (filled plasma contours). Physical constraint overlays (Clausius–Clapeyron saturation curve, geostrophic balance line) are drawn automatically at **500 hPa** when the pair is recognised; at other levels the overlays are suppressed.
 
 **Output files** (per variable pair, per pressure level for 3D variables, per ensemble token):
 
 ```text
-multivariate/bivariate_<var1>_<var2>[_level<N>]_<ens>.png          # density plot
-multivariate/bivariate_hist_<var1>_<var2>[_level<N>]_<ens>.npz     # histogram data
-multivariate/bivariate_by_lead_<var1>_<var2>[_level<N>]_<ens>.png  # per-lead grid (multi-lead only)
+multivariate/bivariate_<var1>_<var2>[_level<N>]_<ens>.png         # density plot
+multivariate/bivariate_<var1>_<var2>[_level<N>]_<ens>.npz         # histogram data
+multivariate/bivariate_by_lead_<var1>_<var2>[_level<N>]_<ens>.png # per-lead grid (multi-lead only)
 ```
 
 NPZ keys: `hist` (prediction), `hist_target` (reference), `bins_x`, `bins_y`, `var_x`, `var_y`, `level_hpa`.

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -124,7 +124,7 @@ ets_line_2m_temperature_data_ensmean.npz
 
 ### Multivariate Metrics (Bivariate Histograms)
 
-Bivariate density plots (histograms) are generated for specified variable pairs (e.g., u10m vs v10m). These plots visualize the joint distribution of two variables, comparing the prediction (grey contours) against the reference (filled plasma contours). Physical constraint overlays (Clausius–Clapeyron saturation curve, geostrophic balance line) are drawn automatically at **500 hPa** when the pair is recognised; at other levels the overlays are suppressed.
+Bivariate density plots (histograms) are generated for specified variable pairs (e.g., u10m vs v10m). These plots visualize the joint distribution of two variables, comparing the prediction (filled plasma contours) against the reference (grey contours). Physical constraint overlays (Clausius–Clapeyron saturation curve, geostrophic balance line) are drawn automatically at **500 hPa** when the pair is recognised; at other levels the overlays are suppressed.
 
 **Output files** (per variable pair, per pressure level for 3D variables, per ensemble token):
 

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -122,9 +122,19 @@ ets_line_2m_temperature_ensmean.png
 ets_line_2m_temperature_data_ensmean.npz
 ```
 
-### Multivariate Metrics
+### Multivariate Metrics (Bivariate Histograms)
 
-Bivariate density plots (histograms) are generated for specified variable pairs (e.g., u10m vs v10m). These plots visualize the joint distribution of two variables, comparing the prediction (grey contours) against the reference (filled plasma contours).
+Bivariate density plots (histograms) are generated for specified variable pairs (e.g., u10m vs v10m). These plots visualize the joint distribution of two variables, comparing the prediction (grey contours) against the reference (filled plasma contours). Physical constraint overlays (e.g. Clausius–Clapeyron saturation curve, geostrophic balance line) are drawn automatically at the appropriate pressure level when the pair is recognised.
+
+**Output files** (per variable pair, per pressure level for 3D variables, per ensemble token):
+
+```text
+multivariate/bivariate_<var1>_<var2>[_level<N>]_<ens>.png          # density plot
+multivariate/bivariate_hist_<var1>_<var2>[_level<N>]_<ens>.npz     # histogram data
+multivariate/bivariate_by_lead_<var1>_<var2>[_level<N>]_<ens>.png  # per-lead grid (multi-lead only)
+```
+
+NPZ keys: `hist` (prediction), `hist_target` (reference), `bins_x`, `bins_y`, `var_x`, `var_y`, `level_hpa`.
 
 **Recommended Bivariate Pairs:**
 
@@ -138,7 +148,7 @@ To evaluate physical consistency, we recommend plotting pairs that capture funda
     *   *Why:* Captures the jet stream structure and synoptic variability. Biases in the spread indicate errors in the storm track or mean flow.
 3.  **Thermodynamics (Clausius-Clapeyron):** `temperature` vs `specific_humidity`.
     *   *Suggested Level:* 850 hPa (Lower Troposphere).
-    *   *Why:* Warmer air holds more moisture. The distribution should show a sharp cutoff at the saturation curve, which follows the Clausius-Clapeyron relation. Points beyond this curve indicate unphysical supersaturation.
+    *   *Why:* Warmer air holds more moisture. The distribution should show a sharp cutoff at the saturation curve (drawn automatically at the actual pressure level). Points beyond this curve indicate unphysical supersaturation.
 4.  **Hydrostatics:** `geopotential` vs `temperature`.
     *   *Suggested Level:* 500 hPa (Mid-troposphere).
     *   *Why:* Relates to hydrostatic balance. Low geopotential heights (troughs) are typically associated with cold air (cold-core cyclones).
@@ -148,10 +158,6 @@ To evaluate physical consistency, we recommend plotting pairs that capture funda
 6.  **Vertical Motion:** `vertical_velocity` vs `temperature`.
     *   *Suggested Level:* 500 hPa (Mid-troposphere).
     *   *Why:* Evaluates convective processes. Upward motion (negative $\omega$) is often driven by buoyancy (warm anomalies) in convective systems. Look for asymmetries between strong narrow updrafts and broad downdrafts.
-
-Outputs:
-- `bivariate_hist_<var1>_<var2>.npz`: Saved histogram counts and bin edges.
-- `bivariate_<var1>_<var2>.png`: The generated density plot comparing the current model (Prediction) against the reference.
 
 ### Energy Spectra Analysis
 
@@ -220,13 +226,6 @@ map_10m_u_component_of_wind_init2023010200-2023010412_ens0.png   # member 0
 map_temperature_500_init2023010200-2023010412_ensmean.png        # mean reduction
 map_10m_u_component_of_wind_init2023010200-2023010412_ens3.npz   # NPZ export (output_mode=npz/both)
 ```
-
-### Bivariate Histograms
-
-Outputs (standardized naming):
-
-- Plot: `multivariate/bivariate_<var1>_<var2>_ens*.png`
-- Data (NPZ): `multivariate/bivariate_hist_<var1>_<var2>_ens*.npz`
 
 **3D variables and multi-lead NPZ files**: For 3D atmospheric variables evaluated with more than one lead time, the NPZ files are saved **per pressure level** (one file per level) with the full lead-time stack preserved:
 

--- a/src/swissclim_evaluations/core/config.py
+++ b/src/swissclim_evaluations/core/config.py
@@ -121,11 +121,6 @@ def _module_metric_threshold_summary(module: str, cfg: dict[str, Any]) -> tuple[
         n_pairs = len(pairs) if isinstance(pairs, list) else 0
         return f"Bivariate Histograms ({n_pairs} pairs)", "n/a"
 
-    if module == "ssim":
-        ssim_cfg = cfg.get("metrics", {}).get("ssim", {})
-        sigma = ssim_cfg.get("sigma", 1.5) if isinstance(ssim_cfg, dict) else 1.5
-        return f"SSIM (sigma={sigma})", "n/a"
-
     return "n/a", "n/a"
 
 
@@ -139,7 +134,6 @@ def print_module_config_summary(cfg: dict[str, Any], chapter_flags: dict[str, An
         "deterministic",
         "ets",
         "probabilistic",
-        "ssim",
         "multivariate",
     ]
     c.section("Configured Metrics/Thresholds")

--- a/src/swissclim_evaluations/core/config.py
+++ b/src/swissclim_evaluations/core/config.py
@@ -115,6 +115,17 @@ def _module_metric_threshold_summary(module: str, cfg: dict[str, Any]) -> tuple[
     if module == "energy_spectra":
         return "LSD", "n/a"
 
+    if module == "multivariate":
+        module_cfg = cfg.get("metrics", {}).get("multivariate", {})
+        pairs = module_cfg.get("bivariate_pairs", [])
+        n_pairs = len(pairs) if isinstance(pairs, list) else 0
+        return f"Bivariate Histograms ({n_pairs} pairs)", "n/a"
+
+    if module == "ssim":
+        ssim_cfg = cfg.get("metrics", {}).get("ssim", {})
+        sigma = ssim_cfg.get("sigma", 1.5) if isinstance(ssim_cfg, dict) else 1.5
+        return f"SSIM (sigma={sigma})", "n/a"
+
     return "n/a", "n/a"
 
 
@@ -128,6 +139,8 @@ def print_module_config_summary(cfg: dict[str, Any], chapter_flags: dict[str, An
         "deterministic",
         "ets",
         "probabilistic",
+        "ssim",
+        "multivariate",
     ]
     c.section("Configured Metrics/Thresholds")
     for module in module_order:

--- a/src/swissclim_evaluations/core/runner.py
+++ b/src/swissclim_evaluations/core/runner.py
@@ -157,6 +157,7 @@ def run_selected(cfg: dict[str, Any]) -> None:
         "deterministic",
         "ets",
         "probabilistic",
+        "multivariate",
     ]
     resolved_modes: dict[str, str] = {}
     for _m in module_names:
@@ -806,6 +807,52 @@ def run_selected(cfg: dict[str, Any]) -> None:
                     "error": "no ensemble dimension",
                 }
             )
+
+    # Multivariate (Bivariate Histograms)
+    if chapter_flags.get("multivariate"):
+        from ..metrics.multivariate import run as run_multivariate
+
+        c.module_status("multivariate", "run", "Bivariate Histograms")
+        if "ensemble" in ds_prediction.dims:
+            ens_size = int(ds_prediction.sizes.get("ensemble", 0))
+            c.info(
+                format_ensemble_log(
+                    "multivariate", ensemble_cfg.get("multivariate", "mean"), ens_size
+                )
+            )
+        else:
+            c.info("No ensemble dimension → deterministic inputs.")
+        _t = time.time()
+        try:
+            run_multivariate(
+                ds_target,
+                ds_prediction,
+                out_root,
+                cfg.get("metrics", {}),
+                ensemble_mode=ensemble_cfg.get("multivariate"),
+            )
+            dt = time.time() - _t
+            module_timings.append(("multivariate", dt))
+            module_results.append(
+                {
+                    "name": "multivariate",
+                    "status": "success",
+                    "seconds": dt,
+                    "error": None,
+                }
+            )
+        except Exception as ex:
+            dt = time.time() - _t
+            c.error(f"multivariate failed: {ex}")
+            module_results.append(
+                {
+                    "name": "multivariate",
+                    "status": "failed",
+                    "seconds": dt,
+                    "error": str(ex),
+                }
+            )
+
     # Final completion message + timings summary + module results summary (pass/fail)
     elapsed = time.time() - t0
     try:

--- a/src/swissclim_evaluations/data.py
+++ b/src/swissclim_evaluations/data.py
@@ -515,12 +515,64 @@ def _wind_speed(ds: xr.Dataset, u_var: str, v_var: str) -> xr.DataArray:
     return da
 
 
+def _geopotential_height(ds: xr.Dataset, u_var: str, v_var: str) -> xr.DataArray:
+    """Lazy geopotential height: Z = geopotential / g₀.  Units: m.
+
+    Only the *source* variable (``u_var``) is used; ``v_var`` is a no-op and
+    should be left as an empty string in the config.
+    """
+    g0 = 9.80665  # standard gravity, m s⁻²
+    da = ds[u_var] / g0
+    da.attrs["units"] = "m"
+    da.attrs["long_name"] = "Geopotential Height"
+    return da
+
+
+def _geopotential_height_gradient(ds: xr.Dataset, u_var: str, v_var: str) -> xr.DataArray:
+    """Horizontal gradient magnitude of geopotential height |∇Z|.  Units: m m⁻¹.
+
+    Computes |∇Z| = sqrt((∂Z/∂y)² + (∂Z/∂x)²) using centred finite differences
+    along the ``latitude`` and ``longitude`` coordinates.  The partial derivatives
+    are converted from degrees⁻¹ to m⁻¹ using the WGS-84 mean Earth radius.
+
+    Only the *source* variable (``u_var``) is used; the variable must already be
+    in metres (geopotential height, not raw geopotential).  Use the
+    ``geopotential_height`` recipe first if you have raw geopotential.
+    """
+    R_earth = 6_371_000.0  # WGS-84 mean radius, m
+    deg2rad = np.pi / 180.0
+
+    Z = ds[u_var]
+    lat = Z["latitude"]  # degrees
+    cos_lat = np.cos(lat * deg2rad)  # broadcast-ready DataArray
+
+    # ∂Z/∂lat  [m / degree] → [m / m] via R_earth [m / rad] and deg2rad
+    dZ_dlat = Z.differentiate("latitude") / (R_earth * deg2rad)  # m m⁻¹
+
+    # ∂Z/∂lon  [m / degree] → [m / m]; longitude arc-length shrinks with cos(lat)
+    dZ_dlon = Z.differentiate("longitude") / (R_earth * deg2rad * cos_lat)  # m m⁻¹
+
+    grad = np.sqrt(dZ_dlat**2 + dZ_dlon**2)
+    grad.attrs["units"] = "m m**-1"
+    grad.attrs["long_name"] = "Geopotential Height Gradient Magnitude"
+    return grad
+
+
 # Maps recipe name → callable(ds, u_var, v_var) → xr.DataArray
 # Available recipes that a user may reference via ``kind:`` in config:
-#   wind_speed  — sqrt(U² + V²), m s⁻¹, suitable for all modules
+#   wind_speed                   — sqrt(U² + V²), m s⁻¹
+#   geopotential_height          — geopotential / 9.80665, m  (single-input)
+#   geopotential_height_gradient — |∇Z|, m m⁻¹               (single-input)
 _DERIVED_RECIPES: dict[str, Any] = {
     "wind_speed": _wind_speed,
+    "geopotential_height": _geopotential_height,
+    "geopotential_height_gradient": _geopotential_height_gradient,
 }
+
+# Recipes that only need a single source variable (u/source); v is unused.
+_SINGLE_INPUT_KINDS: frozenset[str] = frozenset(
+    {"geopotential_height", "geopotential_height_gradient"}
+)
 
 
 def _parse_derived_cfg(
@@ -536,6 +588,13 @@ def _parse_derived_cfg(
           kind: wind_speed                    # see _DERIVED_RECIPES for available kinds
           u: 10m_u_component_of_wind
           v: 10m_v_component_of_wind
+
+        For single-input recipes (e.g. ``geopotential_height``) only ``u``
+        (or the synonym ``source``) is required; ``v`` is unused::
+
+        geopotential_height:
+          kind: geopotential_height
+          u: geopotential
     """
     entries: list[tuple[str, str, str, str]] = []
 
@@ -559,10 +618,16 @@ def _parse_derived_cfg(
             )
             continue
 
-        u_var = str(block.get("u") or block.get("u_var") or "")
+        # Accept 'source' as an alias for 'u' (clearer for single-input recipes).
+        u_var = str(block.get("source") or block.get("u") or block.get("u_var") or "")
         v_var = str(block.get("v") or block.get("v_var") or "")
-        if not u_var or not v_var:
-            c.warn(f"derived_variables.{key}: requires 'u' and 'v' keys. Skipping.")
+
+        if not u_var:
+            c.warn(f"derived_variables.{key}: requires 'u' (or 'source') key. Skipping.")
+            continue
+
+        if kind not in _SINGLE_INPUT_KINDS and not v_var:
+            c.warn(f"derived_variables.{key}: kind '{kind}' requires 'v' key. Skipping.")
             continue
 
         entries.append((key, kind, u_var, v_var))
@@ -580,6 +645,8 @@ def add_derived_variables(
     Currently supported recipes (see ``_DERIVED_RECIPES``):
 
     * ``wind_speed`` — ``sqrt(U² + V²)`` (m s⁻¹)
+    * ``geopotential_height`` — ``geopotential / 9.80665`` (m)
+    * ``geopotential_height_gradient`` — ``|∇Z|`` (m m⁻¹); requires geopotential_height as input
 
     **Inner-join guard**: a derived variable is only added when *both* source
     components are present in *both* the target and prediction datasets.  If a
@@ -613,9 +680,10 @@ def add_derived_variables(
     skipped: list[str] = []
 
     for out_name, kind, u_var, v_var in entries:
-        # Inner-join guard
-        missing_target = {u_var, v_var} - set(ds_target.data_vars)
-        missing_pred = {u_var, v_var} - set(ds_prediction.data_vars)
+        # Inner-join guard: single-input recipes only need u_var
+        src_vars = {u_var} if kind in _SINGLE_INPUT_KINDS else {u_var, v_var}
+        missing_target = src_vars - set(ds_target.data_vars)
+        missing_pred = src_vars - set(ds_prediction.data_vars)
         if missing_target or missing_pred:
             parts: list[str] = []
             if missing_target:

--- a/src/swissclim_evaluations/data.py
+++ b/src/swissclim_evaluations/data.py
@@ -545,6 +545,9 @@ def _geopotential_height_gradient(ds: xr.Dataset, u_var: str, v_var: str) -> xr.
     Z = ds[u_var]
     lat = Z["latitude"]  # degrees
     cos_lat = np.cos(lat * deg2rad)  # broadcast-ready DataArray
+    # Clamp cos_lat to cos(85°) ≈ 0.087 to prevent near-pole singularities
+    # from blowing up the dZ/dlon term at high latitudes.
+    cos_lat = cos_lat.clip(min=float(np.cos(85.0 * deg2rad)))
 
     # ∂Z/∂lat  [m / degree] → [m / m] via R_earth [m / rad] and deg2rad
     dZ_dlat = Z.differentiate("latitude") / (R_earth * deg2rad)  # m m⁻¹

--- a/src/swissclim_evaluations/helpers.py
+++ b/src/swissclim_evaluations/helpers.py
@@ -225,8 +225,8 @@ def time_range_suffix(ds: xr.Dataset) -> str:
     """Build suffix string encoding init_time and lead_time ranges.
 
     Patterns required by tests:
-      - Both dims: 'init_time_<start>_to_<end>__lead_time_<h0>_to_<h1>'
-      - Only one dim present → single segment without separator.
+    - Both dims: 'init_time_<start>_to_<end>__lead_time_<h0>_to_<h1>'
+    - Only one dim present → single segment without separator.
     Datetime formatted as YYYY-MM-DDTHH. Lead times in hours (ints).
     """
     segments: list[str] = []
@@ -376,10 +376,10 @@ def resolve_ensemble_mode(
     """Determine effective ensemble handling mode for a module.
 
     Modes:
-      - mean: reduce ensemble → single field (ensmean)
-      - pooled: treat all members' samples jointly (enspooled)
-      - prob: keep ensemble dimension intrinsically (ensprob)
-      - members: iterate per member producing separate per-member artifacts (ens<idx>)
+    - mean: reduce ensemble → single field (ensmean)
+    - pooled: treat all members' samples jointly (enspooled)
+    - prob: keep ensemble dimension intrinsically (ensprob)
+    - members: iterate per member producing separate per-member artifacts (ens<idx>)
     """
     base = (requested or _DEFAULT_ENSEMBLE_MODES.get(module, "mean")).lower()
     if base not in _VALID_MODES:
@@ -440,9 +440,9 @@ def validate_and_normalize_ensemble_config(
     """Validate and normalize user-specified per-module ensemble modes.
 
     Behaviour:
-      * Accept typo 'member' → normalize to 'members'.
-      * Lower-case values; unknown modes replaced by module default with warning.
-      * If ensemble dim absent, any non-'mean' mode downgraded to 'mean' with warning.
+    * Accept typo 'member' → normalize to 'members'.
+    * Lower-case values; unknown modes replaced by module default with warning.
+    * If ensemble dim absent, any non-'mean' mode downgraded to 'mean' with warning.
 
     Returns (normalized_config, warnings_list).
     """
@@ -770,7 +770,7 @@ def subsample_values(
         k: Number of samples to take (approximate)
         seed: Random seed
         lazy: If True, return a dask array without computing.
-              If False, compute and return numpy array with finite values only.
+            If False, compute and return numpy array with finite values only.
     """
     size = int(getattr(da, "size", 0) or 0)
     if size == 0:

--- a/src/swissclim_evaluations/helpers.py
+++ b/src/swissclim_evaluations/helpers.py
@@ -342,6 +342,7 @@ _DEFAULT_ENSEMBLE_MODES: dict[str, str] = {
     "deterministic": "mean",
     "ets": "mean",
     "probabilistic": "prob",
+    "multivariate": "mean",
     # plots / diagnostics
     "energy_spectra": "mean",
     "vertical_profiles": "mean",
@@ -362,6 +363,7 @@ _ALLOWED_PER_MODULE: dict[str, set[str]] = {
     "energy_spectra": {"mean", "pooled", "members"},
     "deterministic": {"mean", "pooled", "members"},
     "ets": {"mean", "pooled", "members"},
+    "multivariate": {"mean", "pooled", "members"},
 }
 
 
@@ -693,6 +695,9 @@ VARIABLE_UNITS = {
     # Derived wind variables
     "wind_speed": "m s**-1",
     "10m_wind_speed": "m s**-1",
+    # Derived geopotential height and its gradient
+    "geopotential_height": "m",
+    "geopotential_height_gradient": "m m**-1",
     "geopotential": "m**2 s**-2",
     "specific_humidity": "kg kg**-1",
     "mean_sea_level_pressure": "Pa",
@@ -700,15 +705,43 @@ VARIABLE_UNITS = {
 }
 
 
+def _to_latex_units(unit_str: str) -> str:
+    """Convert CF-style unit strings to LaTeX ratio notation.
+
+    Examples: 'm s**-1' -> '$\\mathrm{m/s}$', 'kg kg**-1' -> '$\\mathrm{kg/kg}$',
+    's**-1' -> '$\\mathrm{1/s}$', 'm**2 s**-2' -> '$\\mathrm{m^{2}/s^{2}}$'.
+    """
+    if not unit_str:
+        return unit_str
+    if "$" in unit_str or "\\" in unit_str:
+        return unit_str  # already LaTeX
+    # Convert ** exponent notation to ^{N}
+    s = re.sub(r"\*\*(-?\d+)", lambda m: f"^{{{m.group(1)}}}", unit_str)
+    # Split tokens and separate into numerator / denominator by exponent sign
+    _neg = re.compile(r"^(.+?)\^\{(-\d+)\}$")
+    numer: list[str] = []
+    denom: list[str] = []
+    for tok in s.split():
+        m = _neg.match(tok)
+        if m:
+            base, abs_exp = m.group(1), -int(m.group(2))
+            denom.append(base if abs_exp == 1 else f"{base}^{{{abs_exp}}}")
+        else:
+            numer.append(tok)
+    numer_str = r"\,".join(numer) if numer else "1"
+    combined = numer_str + "/" + r"\,".join(denom) if denom else numer_str
+    return rf"$\mathrm{{{combined}}}$"
+
+
 def get_variable_units(ds: xr.Dataset | xr.DataArray | None, var_name: str) -> str:
     """Get units for a variable, falling back to a default mapping if missing."""
     if ds is not None:
         if isinstance(ds, xr.DataArray):
             if "units" in ds.attrs:
-                return str(ds.attrs["units"])
+                return _to_latex_units(str(ds.attrs["units"]))
         elif var_name in ds and "units" in ds[var_name].attrs:
-            return str(ds[var_name].attrs["units"])
-    return VARIABLE_UNITS.get(var_name, "")
+            return _to_latex_units(str(ds[var_name].attrs["units"]))
+    return _to_latex_units(VARIABLE_UNITS.get(var_name, ""))
 
 
 def subsample_values(

--- a/src/swissclim_evaluations/helpers.py
+++ b/src/swissclim_evaluations/helpers.py
@@ -628,8 +628,44 @@ def extract_date_from_dataset(ds: Any) -> str:
     return ""
 
 
+# Short display names for known variables.
+# Follows ECMWF paramDB short names (uppercased) where applicable:
+#   geopotential       param 129 → "z"  → Z   (m²/s²)
+#   geopotential_height param 156 → "gh" → GH  (gpm)  — distinct from Z in the paper
+#   wind speed         derived   → "ws" → WS
+VARIABLE_SHORT_NAMES: dict[str, str] = {
+    # Surface
+    "2m_temperature": "T2m",
+    "10m_u_component_of_wind": "U10m",
+    "10m_v_component_of_wind": "V10m",
+    "10m_wind_speed": "WS10m",
+    # Pressure-level
+    "temperature": "T",
+    "u_component_of_wind": "U",
+    "v_component_of_wind": "V",
+    "specific_humidity": "Q",
+    "vertical_velocity": "W",
+    # Geopotential / height (ECMWF paramDB: z / gh)
+    "geopotential": "Z",
+    "geopotential_height": "GH",
+    "geopotential_height_gradient": r"$|\nabla\mathrm{GH}|$",
+    # Wind speed (ECMWF paramDB: ws)
+    "wind_speed": "WS",
+    # Precipitation / moisture
+    "total_precipitation": "TP",
+    "total_column_water_vapour": "TCWV",
+    "mean_sea_level_pressure": "MSLP",
+}
+
+
 def format_variable_name(var_name: str) -> str:
-    """Format variable name for plot titles (e.g. '2m_temperature' -> '2m Temperature')."""
+    """Return a short display name for a variable.
+
+    Looks up ``VARIABLE_SHORT_NAMES`` first; falls back to capitalising the
+    underscore-separated tokens (legacy behaviour).
+    """
+    if var_name in VARIABLE_SHORT_NAMES:
+        return VARIABLE_SHORT_NAMES[var_name]
     formatted = " ".join(word.capitalize() for word in var_name.replace("_", " ").split())
     # Remove trailing 2d/3d indicators
     lower = formatted.lower()

--- a/src/swissclim_evaluations/helpers.py
+++ b/src/swissclim_evaluations/helpers.py
@@ -733,15 +733,28 @@ def _to_latex_units(unit_str: str) -> str:
     return rf"$\mathrm{{{combined}}}$"
 
 
-def get_variable_units(ds: xr.Dataset | xr.DataArray | None, var_name: str) -> str:
-    """Get units for a variable, falling back to a default mapping if missing."""
+def get_variable_units(
+    ds: xr.Dataset | xr.DataArray | None, var_name: str, latex: bool = False
+) -> str:
+    """Get units for a variable, falling back to a default mapping if missing.
+
+    Args:
+        ds: Dataset or DataArray to read units from, or ``None``.
+        var_name: Variable name used for the fallback lookup.
+        latex: If ``True``, return LaTeX-formatted units suitable for plot
+            labels.  If ``False`` (default), return plain CF-style strings
+            suitable for metadata, CSV headers, and downstream unit parsing.
+    """
     if ds is not None:
         if isinstance(ds, xr.DataArray):
             if "units" in ds.attrs:
-                return _to_latex_units(str(ds.attrs["units"]))
+                raw = str(ds.attrs["units"])
+                return _to_latex_units(raw) if latex else raw
         elif var_name in ds and "units" in ds[var_name].attrs:
-            return _to_latex_units(str(ds[var_name].attrs["units"]))
-    return _to_latex_units(VARIABLE_UNITS.get(var_name, ""))
+            raw = str(ds[var_name].attrs["units"])
+            return _to_latex_units(raw) if latex else raw
+    raw = VARIABLE_UNITS.get(var_name, "")
+    return _to_latex_units(raw) if latex else raw
 
 
 def subsample_values(

--- a/src/swissclim_evaluations/intercompare.py
+++ b/src/swissclim_evaluations/intercompare.py
@@ -22,6 +22,7 @@ from swissclim_evaluations.intercomparison.modules.histograms import (
     intercompare_histograms,
 )
 from swissclim_evaluations.intercomparison.modules.maps import intercompare_maps
+from swissclim_evaluations.intercomparison.modules.multivariate import intercompare_multivariate
 from swissclim_evaluations.intercomparison.modules.probabilistic import (
     intercompare_probabilistic,
 )
@@ -292,6 +293,8 @@ def run_from_config(cfg: dict) -> None:
         intercompare_probabilistic(
             models, labels, out_root, max_crps_map_panels=max_crps_map_panels
         )
+    if "multivariate" in mods:
+        intercompare_multivariate(models, labels, out_root)
 
     c.success("Intercomparison finished.")
 

--- a/src/swissclim_evaluations/intercompare.py
+++ b/src/swissclim_evaluations/intercompare.py
@@ -73,6 +73,7 @@ MODULE_ALIASES: dict[str, str] = {
     "deterministic_metrics": "metrics",
     "energy": "spectra",
     "vertical": "vprof",
+    "multivariate": "multivariate",
 }
 
 
@@ -105,6 +106,7 @@ MODULE_INPUT_PATTERNS: dict[str, tuple[str, ...]] = {
         "probabilistic/pit_hist*.npz",
         "probabilistic/crps_map_*.npz",
     ),
+    "multivariate": ("multivariate/bivariate_*.npz",),
 }
 
 
@@ -247,6 +249,7 @@ def run_from_config(cfg: dict) -> None:
         "ets",
         "prob",
         "vprof",
+        "multivariate",
     ]
     modules = [str(m).lower() for m in modules]
     # Other options

--- a/src/swissclim_evaluations/intercomparison/modules/multivariate.py
+++ b/src/swissclim_evaluations/intercomparison/modules/multivariate.py
@@ -10,7 +10,7 @@ from matplotlib.cm import ScalarMappable
 from matplotlib.colors import LogNorm
 
 from swissclim_evaluations import console as c
-from swissclim_evaluations.helpers import format_variable_name
+from swissclim_evaluations.helpers import format_variable_name, get_variable_units
 from swissclim_evaluations.intercomparison.core import (
     common_files,
     ensure_dir,
@@ -49,6 +49,29 @@ def _scalar_float(value: np.ndarray | float | None) -> float | None:
     if np.isnan(val):
         return None
     return val
+
+
+def _extract_units(payload: dict[str, np.ndarray], axis: str) -> str | None:
+    if axis not in {"x", "y"}:
+        return None
+    for key in (
+        f"units_{axis}",
+        f"unit_{axis}",
+        f"{axis}_units",
+        f"{axis}_unit",
+        f"var_{axis}_units",
+        f"var_{axis}_unit",
+    ):
+        units = _scalar_str(payload.get(key))
+        if units:
+            return units
+    return None
+
+
+def _format_axis_label(var_name: str, units: str | None = None) -> str:
+    label = format_variable_name(var_name)
+    resolved_units = units or get_variable_units(None, var_name, latex=True)
+    return f"{label} [{resolved_units}]" if resolved_units else label
 
 
 def _infer_var_pair(fname: str, payload: dict[str, np.ndarray]) -> tuple[str, str]:
@@ -108,6 +131,10 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
             )
         level_hpa = _scalar_float(first_payload.get("level_hpa"))
         coriolis_parameter = _scalar_float(first_payload.get("coriolis_parameter")) or 1.0e-4
+        unit_x = _extract_units(first_payload, "x")
+        unit_y = _extract_units(first_payload, "y")
+        xlabel = _format_axis_label(var_x, unit_x) if var_x else ""
+        ylabel = _format_axis_label(var_y, unit_y) if var_y else ""
 
         ref_hist_target = np.asarray(first_payload["hist_target"])
         ref_bins_x = np.asarray(first_payload["bins_x"])
@@ -238,8 +265,8 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 var_y=var_y,
                 level_hpa=level_hpa,
                 ax=ax,
-                xlabel=format_variable_name(var_x) if (var_x and is_bottom) else None,
-                ylabel=format_variable_name(var_y) if var_y else None,
+                xlabel=xlabel if (xlabel and is_bottom) else None,
+                ylabel=ylabel if ylabel else None,
                 xlim=shared_xlim,
                 ylim=shared_ylim,
                 show_colorbar=False,
@@ -290,7 +317,9 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
 
         stem = fname.replace("bivariate_", "").replace(".npz", "")
         out_png = dst / f"bivariate_{stem}_compare.png"
+        out_pdf = dst / f"bivariate_{stem}_compare.pdf"
         fig.savefig(out_png, dpi=150)
+        fig.savefig(out_pdf)
         plt.close(fig)
 
         out_npz = dst / f"bivariate_{stem}_compare.npz"
@@ -344,4 +373,5 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
             )
 
         c.success(f"[multivariate] Saved compare plot: {out_png}")
+        c.success(f"[multivariate] Saved compare plot: {out_pdf}")
         c.success(f"[multivariate] Saved combined artifact: {out_npz}")

--- a/src/swissclim_evaluations/intercomparison/modules/multivariate.py
+++ b/src/swissclim_evaluations/intercomparison/modules/multivariate.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swissclim_evaluations import console as c
+from swissclim_evaluations.helpers import format_variable_name
+from swissclim_evaluations.intercomparison.core import (
+    common_files,
+    ensure_dir,
+    print_file_list,
+    report_checklist,
+    report_missing,
+    scan_model_sets,
+)
+from swissclim_evaluations.plots.bivariate_histograms import plot_bivariate_histogram
+
+
+def _load_hist_payload(path: Path) -> dict[str, np.ndarray]:
+    with np.load(path, allow_pickle=True) as payload:
+        return {k: payload[k] for k in payload.files}
+
+
+def _scalar_str(value: np.ndarray | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, np.ndarray):
+        if value.shape == ():
+            return str(value.item())
+        if value.size == 1:
+            return str(value.reshape(-1)[0])
+        return None
+    return str(value)
+
+
+def _scalar_float(value: np.ndarray | float | None) -> float | None:
+    if value is None:
+        return None
+    arr = np.asarray(value)
+    if arr.size == 0:
+        return None
+    val = float(arr.reshape(-1)[0])
+    if np.isnan(val):
+        return None
+    return val
+
+
+def _infer_var_pair(fname: str, payload: dict[str, np.ndarray]) -> tuple[str, str]:
+    var_x = _scalar_str(payload.get("var_x"))
+    var_y = _scalar_str(payload.get("var_y"))
+    if var_x and var_y:
+        return var_x, var_y
+
+    stem = fname.replace("bivariate_hist_", "").replace(".npz", "")
+    stem = re.sub(r"_ens[a-zA-Z0-9]+$", "", stem)
+
+    known_pairs = [
+        ("temperature", "specific_humidity"),
+        ("specific_humidity", "temperature"),
+        ("geopotential_height", "wind_speed"),
+        ("wind_speed", "geopotential_height"),
+        ("geopotential_height_gradient", "wind_speed"),
+        ("wind_speed", "geopotential_height_gradient"),
+    ]
+    for a, b in known_pairs:
+        token = f"{a}_{b}"
+        if stem == token:
+            return a, b
+
+    return "", ""
+
+
+def intercompare_multivariate(models: list[Path], labels: list[str], out_root: Path) -> None:
+    """Compare multivariate bivariate-histogram artifacts across models."""
+    pattern = "multivariate/bivariate_hist_*.npz"
+
+    per_model, _, uni = scan_model_sets(models, pattern)
+    report_missing("multivariate", models, labels, per_model, uni)
+
+    common = common_files(models, pattern)
+    report_checklist("multivariate", {"Bivariate histograms": len(common)})
+
+    if not common:
+        c.warn("No common multivariate NPZ files found. Skipping multivariate intercomparison.")
+        return
+
+    print_file_list(f"Found {len(common)} common multivariate files", common)
+    dst = ensure_dir(out_root / "multivariate")
+
+    for fname in common:
+        first_payload = _load_hist_payload(models[0] / "multivariate" / fname)
+        if not {"hist_target", "bins_x", "bins_y"}.issubset(first_payload):
+            c.warn(f"[multivariate] Skipping {fname}: missing required target/bin arrays")
+            continue
+
+        var_x, var_y = _infer_var_pair(fname, first_payload)
+        level_hpa = _scalar_float(first_payload.get("level_hpa"))
+
+        ref_hist_target = np.asarray(first_payload["hist_target"])
+        ref_bins_x = np.asarray(first_payload["bins_x"])
+        ref_bins_y = np.asarray(first_payload["bins_y"])
+
+        model_entries: list[dict[str, np.ndarray | str]] = []
+
+        for label, model_dir in zip(labels, models, strict=False):
+            payload = _load_hist_payload(model_dir / "multivariate" / fname)
+            required = {"hist", "hist_target", "bins_x", "bins_y"}
+            if not required.issubset(payload):
+                c.warn(
+                    f"[multivariate] Missing required arrays in "
+                    f"{model_dir / 'multivariate' / fname}"
+                )
+                continue
+
+            hist = np.asarray(payload["hist"])
+            hist_target = np.asarray(payload["hist_target"])
+            bins_x = np.asarray(payload["bins_x"])
+            bins_y = np.asarray(payload["bins_y"])
+
+            if hist.shape != hist_target.shape:
+                c.warn(
+                    f"[multivariate] Shape mismatch for {fname} in {label}: "
+                    f"model={hist.shape}, target={hist_target.shape}; skipped"
+                )
+                continue
+
+            model_entries.append(
+                {
+                    "label": label,
+                    "hist": hist,
+                    "hist_target": hist_target,
+                    "bins_x": bins_x,
+                    "bins_y": bins_y,
+                }
+            )
+
+        if not model_entries:
+            c.warn(f"[multivariate] No valid model histograms for {fname}; skipped")
+            continue
+
+        # Use common axis limits across all model panels for this pair.
+        # This guarantees directly comparable visual placement between subplots.
+        all_x_min = min(float(np.asarray(entry["bins_x"]).min()) for entry in model_entries)
+        all_x_max = max(float(np.asarray(entry["bins_x"]).max()) for entry in model_entries)
+        all_y_min = min(float(np.asarray(entry["bins_y"]).min()) for entry in model_entries)
+        all_y_max = max(float(np.asarray(entry["bins_y"]).max()) for entry in model_entries)
+
+        x_range = all_x_max - all_x_min
+        y_range = all_y_max - all_y_min
+        x_center = (all_x_max + all_x_min) / 2.0
+        y_center = (all_y_max + all_y_min) / 2.0
+        shared_xlim = (x_center - 0.625 * x_range, x_center + 0.625 * x_range)
+        shared_ylim = (y_center - 0.625 * y_range, y_center + 0.625 * y_range)
+
+        # Warn when models were produced on different histogram grids.
+        off_grid_labels = [
+            str(entry["label"])
+            for entry in model_entries
+            if not (
+                np.array_equal(np.asarray(entry["bins_x"]), ref_bins_x)
+                and np.array_equal(np.asarray(entry["bins_y"]), ref_bins_y)
+            )
+        ]
+        if off_grid_labels:
+            c.warn(
+                "[multivariate] Inconsistent histogram bin grids detected in "
+                f"{fname}. Using per-model bins/target to avoid contour misalignment. "
+                f"Affected: {', '.join(off_grid_labels)}"
+            )
+
+        n_cols = len(model_entries)
+        fig, axes = plt.subplots(1, n_cols, figsize=(6 * n_cols, 6), squeeze=False)
+
+        for idx, entry in enumerate(model_entries):
+            ax = axes[0, idx]
+            hist = np.asarray(entry["hist"])
+            hist_target = np.asarray(entry["hist_target"])
+            bins_x = np.asarray(entry["bins_x"])
+            bins_y = np.asarray(entry["bins_y"])
+            label = str(entry["label"])
+            plot_bivariate_histogram(
+                hist_1=hist,
+                hist_2=hist_target,
+                bins_x=bins_x,
+                bins_y=bins_y,
+                label_1=label,
+                label_2="Target",
+                var_x=var_x,
+                var_y=var_y,
+                level_hpa=level_hpa,
+                ax=ax,
+                xlabel=format_variable_name(var_x) if var_x else None,
+                ylabel=format_variable_name(var_y) if var_y else None,
+                xlim=shared_xlim,
+                ylim=shared_ylim,
+            )
+            ax.set_title(label)
+
+        if var_x and var_y:
+            title = f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}"
+            if level_hpa is not None:
+                title += f" ({level_hpa:g} hPa)"
+            fig.suptitle(title)
+        else:
+            fig.suptitle(fname.replace("bivariate_hist_", "").replace(".npz", ""))
+        fig.tight_layout()
+
+        stem = fname.replace("bivariate_hist_", "").replace(".npz", "")
+        out_png = dst / f"bivariate_{stem}_compare.png"
+        fig.savefig(out_png, dpi=150)
+        plt.close(fig)
+
+        out_npz = dst / f"bivariate_hist_{stem}_compare.npz"
+        valid_labels = [str(entry["label"]) for entry in model_entries]
+        uniform_grid = all(
+            np.array_equal(np.asarray(entry["bins_x"]), ref_bins_x)
+            and np.array_equal(np.asarray(entry["bins_y"]), ref_bins_y)
+            for entry in model_entries
+        )
+        uniform_target = all(
+            np.array_equal(np.asarray(entry["hist_target"]), ref_hist_target)
+            for entry in model_entries
+        )
+
+        if uniform_grid and uniform_target:
+            np.savez(
+                out_npz,
+                bins_x=ref_bins_x,
+                bins_y=ref_bins_y,
+                hist_target=ref_hist_target,
+                var_x=var_x,
+                var_y=var_y,
+                level_hpa=np.nan if level_hpa is None else level_hpa,
+                model_labels=np.array(valid_labels, dtype=object),
+                hist_models=np.stack(
+                    [np.asarray(entry["hist"]) for entry in model_entries], axis=0
+                ),
+            )
+        else:
+            np.savez(
+                out_npz,
+                var_x=var_x,
+                var_y=var_y,
+                level_hpa=np.nan if level_hpa is None else level_hpa,
+                model_labels=np.array(valid_labels, dtype=object),
+                hist_models=np.array(
+                    [np.asarray(entry["hist"]) for entry in model_entries], dtype=object
+                ),
+                hist_targets=np.array(
+                    [np.asarray(entry["hist_target"]) for entry in model_entries], dtype=object
+                ),
+                bins_x_list=np.array(
+                    [np.asarray(entry["bins_x"]) for entry in model_entries], dtype=object
+                ),
+                bins_y_list=np.array(
+                    [np.asarray(entry["bins_y"]) for entry in model_entries], dtype=object
+                ),
+                bins_x_ref=ref_bins_x,
+                bins_y_ref=ref_bins_y,
+                hist_target_ref=ref_hist_target,
+            )
+
+        c.success(f"[multivariate] Saved compare plot: {out_png}")
+        c.success(f"[multivariate] Saved combined artifact: {out_npz}")

--- a/src/swissclim_evaluations/intercomparison/modules/multivariate.py
+++ b/src/swissclim_evaluations/intercomparison/modules/multivariate.py
@@ -97,6 +97,12 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
             continue
 
         var_x, var_y = _infer_var_pair(fname, first_payload)
+        if not var_x or not var_y:
+            c.warn(
+                f"[multivariate] Could not infer var_x/var_y from {fname}; "
+                "axis labels will be empty. Add a recognised pair to known_pairs or "
+                "ensure the NPZ was saved with var_x/var_y keys."
+            )
         level_hpa = _scalar_float(first_payload.get("level_hpa"))
 
         ref_hist_target = np.asarray(first_payload["hist_target"])

--- a/src/swissclim_evaluations/intercomparison/modules/multivariate.py
+++ b/src/swissclim_evaluations/intercomparison/modules/multivariate.py
@@ -200,6 +200,7 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
         global_norm = LogNorm(vmin=global_vmin, vmax=global_vmax)
 
         n_cols = len(model_entries)
+        font_scale = max(1.0, n_cols**0.4)
         fig, axes = plt.subplots(
             1, n_cols, figsize=(6 * n_cols, 7), dpi=150, constrained_layout=True, squeeze=False
         )
@@ -229,8 +230,9 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 show_colorbar=False,
                 show_legend=(idx == 0),
                 coriolis_parameter=coriolis_parameter,
+                font_scale=font_scale,
             )
-            ax.set_title(label)
+            ax.set_title(label, fontsize=int(round(12 * font_scale)))
             if idx != 0:
                 ax.set_ylabel("")
                 ax.tick_params(axis="y", labelleft=False)
@@ -249,15 +251,19 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
         )
         cbar.ax.xaxis.set_major_locator(mticker.LogLocator())
         cbar.ax.xaxis.set_major_formatter(mticker.LogFormatterMathtext())
-        cbar.set_label("Density (log scale)")
+        cbar.set_label("Density (log scale)", fontsize=int(round(11 * font_scale)))
+        cbar.ax.tick_params(labelsize=int(round(9 * font_scale)))
 
         if var_x and var_y:
             title = f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}"
             if level_hpa is not None:
                 title += f" ({level_hpa:g} hPa)"
-            fig.suptitle(title)
+            fig.suptitle(title, fontsize=int(round(14 * font_scale)))
         else:
-            fig.suptitle(fname.replace("bivariate_", "").replace(".npz", ""))
+            fig.suptitle(
+                fname.replace("bivariate_", "").replace(".npz", ""),
+                fontsize=int(round(14 * font_scale)),
+            )
 
         stem = fname.replace("bivariate_", "").replace(".npz", "")
         out_png = dst / f"bivariate_{stem}_compare.png"

--- a/src/swissclim_evaluations/intercomparison/modules/multivariate.py
+++ b/src/swissclim_evaluations/intercomparison/modules/multivariate.py
@@ -199,19 +199,34 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
             global_vmin = 1e-10
         global_norm = LogNorm(vmin=global_vmin, vmax=global_vmax)
 
-        n_cols = len(model_entries)
+        n_models = len(model_entries)
+        max_cols = 3
+        n_cols = min(max_cols, n_models)
+        n_rows = int(np.ceil(n_models / n_cols))
+        n_panels = n_cols * n_rows
         font_scale = max(1.0, n_cols**0.4)
         fig, axes = plt.subplots(
-            1, n_cols, figsize=(6 * n_cols, 7), dpi=150, constrained_layout=True, squeeze=False
+            n_rows,
+            n_cols,
+            figsize=(6 * n_cols, 7 * n_rows),
+            dpi=150,
+            constrained_layout=True,
+            squeeze=False,
         )
+        # Reserve space at the top so the suptitle has breathing room below it.
+        fig.get_layout_engine().set(rect=(0, 0, 1, 0.97))
+        axs_flat = axes.flatten()
 
         for idx, entry in enumerate(model_entries):
-            ax = axes[0, idx]
+            ax = axs_flat[idx]
             hist = np.asarray(entry["hist"])
             hist_target = np.asarray(entry["hist_target"])
             bins_x = np.asarray(entry["bins_x"])
             bins_y = np.asarray(entry["bins_y"])
             label = str(entry["label"])
+            col = idx % n_cols
+            last_row_start = (n_rows - 1) * n_cols
+            is_bottom = idx >= last_row_start
             plot_bivariate_histogram(
                 hist_1=hist,
                 hist_2=hist_target,
@@ -223,7 +238,7 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 var_y=var_y,
                 level_hpa=level_hpa,
                 ax=ax,
-                xlabel=format_variable_name(var_x) if var_x else None,
+                xlabel=format_variable_name(var_x) if (var_x and is_bottom) else None,
                 ylabel=format_variable_name(var_y) if var_y else None,
                 xlim=shared_xlim,
                 ylim=shared_ylim,
@@ -233,16 +248,23 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 font_scale=font_scale,
             )
             ax.set_title(label, fontsize=int(round(12 * font_scale)))
-            if idx != 0:
+            if not is_bottom:
+                ax.set_xlabel("")
+                ax.tick_params(axis="x", labelbottom=False)
+            if col != 0:
                 ax.set_ylabel("")
                 ax.tick_params(axis="y", labelleft=False)
+
+        # Hide surplus axes in the last row.
+        for idx in range(n_models, n_panels):
+            axs_flat[idx].set_visible(False)
 
         # ── Shared horizontal colorbar at the bottom ──────────────────────────
         sm = ScalarMappable(cmap="plasma", norm=global_norm)
         sm.set_array([])
         cbar = fig.colorbar(
             sm,
-            ax=axes[0, :].tolist(),
+            ax=axs_flat[:n_models].tolist(),
             orientation="horizontal",
             location="bottom",
             pad=0.04,
@@ -253,6 +275,7 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
         cbar.ax.xaxis.set_major_formatter(mticker.LogFormatterMathtext())
         cbar.set_label("Density (log scale)", fontsize=int(round(11 * font_scale)))
         cbar.ax.tick_params(labelsize=int(round(9 * font_scale)))
+        font_scale = max(1.0, n_panels**0.4)
 
         if var_x and var_y:
             title = f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}"

--- a/src/swissclim_evaluations/intercomparison/modules/multivariate.py
+++ b/src/swissclim_evaluations/intercomparison/modules/multivariate.py
@@ -54,7 +54,7 @@ def _infer_var_pair(fname: str, payload: dict[str, np.ndarray]) -> tuple[str, st
     if var_x and var_y:
         return var_x, var_y
 
-    stem = fname.replace("bivariate_hist_", "").replace(".npz", "")
+    stem = fname.replace("bivariate_", "").replace(".npz", "")
     stem = re.sub(r"_ens[a-zA-Z0-9]+$", "", stem)
 
     known_pairs = [
@@ -75,7 +75,7 @@ def _infer_var_pair(fname: str, payload: dict[str, np.ndarray]) -> tuple[str, st
 
 def intercompare_multivariate(models: list[Path], labels: list[str], out_root: Path) -> None:
     """Compare multivariate bivariate-histogram artifacts across models."""
-    pattern = "multivariate/bivariate_hist_*.npz"
+    pattern = "multivariate/bivariate_*.npz"
 
     per_model, _, uni = scan_model_sets(models, pattern)
     report_missing("multivariate", models, labels, per_model, uni)
@@ -211,15 +211,15 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 title += f" ({level_hpa:g} hPa)"
             fig.suptitle(title)
         else:
-            fig.suptitle(fname.replace("bivariate_hist_", "").replace(".npz", ""))
+            fig.suptitle(fname.replace("bivariate_", "").replace(".npz", ""))
         fig.tight_layout()
 
-        stem = fname.replace("bivariate_hist_", "").replace(".npz", "")
+        stem = fname.replace("bivariate_", "").replace(".npz", "")
         out_png = dst / f"bivariate_{stem}_compare.png"
         fig.savefig(out_png, dpi=150)
         plt.close(fig)
 
-        out_npz = dst / f"bivariate_hist_{stem}_compare.npz"
+        out_npz = dst / f"bivariate_{stem}_compare.npz"
         valid_labels = [str(entry["label"]) for entry in model_entries]
         uniform_grid = all(
             np.array_equal(np.asarray(entry["bins_x"]), ref_bins_x)

--- a/src/swissclim_evaluations/intercomparison/modules/multivariate.py
+++ b/src/swissclim_evaluations/intercomparison/modules/multivariate.py
@@ -4,7 +4,10 @@ import re
 from pathlib import Path
 
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
 import numpy as np
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import LogNorm
 
 from swissclim_evaluations import console as c
 from swissclim_evaluations.helpers import format_variable_name
@@ -104,6 +107,7 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 "ensure the NPZ was saved with var_x/var_y keys."
             )
         level_hpa = _scalar_float(first_payload.get("level_hpa"))
+        coriolis_parameter = _scalar_float(first_payload.get("coriolis_parameter")) or 1.0e-4
 
         ref_hist_target = np.asarray(first_payload["hist_target"])
         ref_bins_x = np.asarray(first_payload["bins_x"])
@@ -177,8 +181,28 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 f"Affected: {', '.join(off_grid_labels)}"
             )
 
+        # ── Global log-norm across all model histograms for a shared colorbar ──
+        all_vals = []
+        for entry in model_entries:
+            for key in ("hist", "hist_target"):
+                h = np.asarray(entry[key])
+                pos = h[h > 0]
+                if pos.size:
+                    all_vals.append(pos)
+        if all_vals:
+            combined = np.concatenate(all_vals)
+            global_vmin = float(combined.min())
+            global_vmax = float(combined.max())
+        else:
+            global_vmin, global_vmax = 1e-10, 1.0
+        if global_vmin <= 0:
+            global_vmin = 1e-10
+        global_norm = LogNorm(vmin=global_vmin, vmax=global_vmax)
+
         n_cols = len(model_entries)
-        fig, axes = plt.subplots(1, n_cols, figsize=(6 * n_cols, 6), squeeze=False)
+        fig, axes = plt.subplots(
+            1, n_cols, figsize=(6 * n_cols, 7), dpi=150, constrained_layout=True, squeeze=False
+        )
 
         for idx, entry in enumerate(model_entries):
             ax = axes[0, idx]
@@ -192,7 +216,7 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 hist_2=hist_target,
                 bins_x=bins_x,
                 bins_y=bins_y,
-                label_1=label,
+                label_1="Prediction",
                 label_2="Target",
                 var_x=var_x,
                 var_y=var_y,
@@ -202,8 +226,30 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 ylabel=format_variable_name(var_y) if var_y else None,
                 xlim=shared_xlim,
                 ylim=shared_ylim,
+                show_colorbar=False,
+                show_legend=(idx == 0),
+                coriolis_parameter=coriolis_parameter,
             )
             ax.set_title(label)
+            if idx != 0:
+                ax.set_ylabel("")
+                ax.tick_params(axis="y", labelleft=False)
+
+        # ── Shared horizontal colorbar at the bottom ──────────────────────────
+        sm = ScalarMappable(cmap="plasma", norm=global_norm)
+        sm.set_array([])
+        cbar = fig.colorbar(
+            sm,
+            ax=axes[0, :].tolist(),
+            orientation="horizontal",
+            location="bottom",
+            pad=0.04,
+            fraction=0.08,
+            shrink=1.0,
+        )
+        cbar.ax.xaxis.set_major_locator(mticker.LogLocator())
+        cbar.ax.xaxis.set_major_formatter(mticker.LogFormatterMathtext())
+        cbar.set_label("Density (log scale)")
 
         if var_x and var_y:
             title = f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}"
@@ -212,7 +258,6 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
             fig.suptitle(title)
         else:
             fig.suptitle(fname.replace("bivariate_", "").replace(".npz", ""))
-        fig.tight_layout()
 
         stem = fname.replace("bivariate_", "").replace(".npz", "")
         out_png = dst / f"bivariate_{stem}_compare.png"

--- a/src/swissclim_evaluations/intercomparison/modules/multivariate.py
+++ b/src/swissclim_evaluations/intercomparison/modules/multivariate.py
@@ -244,19 +244,27 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
         fig.get_layout_engine().set(rect=(0, 0, 1, 0.97))
         axs_flat = axes.flatten()
 
+        # Use ONE shared truth histogram (from the first model) for every
+        # panel. Otherwise each panel renders the truth contours from its own
+        # ``hist_target``, which can differ in mass and shape if models were
+        # evaluated against slightly different time-matching, masking, or
+        # member subsetting. Using the first model's target guarantees the
+        # truth contour lines are byte-identical across panels.
+        ref_target = np.asarray(model_entries[0]["hist_target"])
+        shared_target_cs = None
+
         for idx, entry in enumerate(model_entries):
             ax = axs_flat[idx]
             hist = np.asarray(entry["hist"])
-            hist_target = np.asarray(entry["hist_target"])
             bins_x = np.asarray(entry["bins_x"])
             bins_y = np.asarray(entry["bins_y"])
             label = str(entry["label"])
             col = idx % n_cols
             last_row_start = (n_rows - 1) * n_cols
             is_bottom = idx >= last_row_start
-            plot_bivariate_histogram(
+            _result = plot_bivariate_histogram(
                 hist_1=hist,
-                hist_2=hist_target,
+                hist_2=ref_target,
                 bins_x=bins_x,
                 bins_y=bins_y,
                 label_1="Prediction",
@@ -267,6 +275,7 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
                 ax=ax,
                 xlabel=xlabel if (xlabel and is_bottom) else None,
                 ylabel=ylabel if ylabel else None,
+                return_contour_sets=True,
                 xlim=shared_xlim,
                 ylim=shared_ylim,
                 show_colorbar=False,
@@ -281,6 +290,14 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
             if col != 0:
                 ax.set_ylabel("")
                 ax.tick_params(axis="y", labelleft=False)
+            # Capture the truth contour set once, so the shared colorbar can
+            # add greyscale level marks via ``cbar.add_lines`` below. This
+            # restores the contour-line annotations that the per-panel
+            # colorbars carry in single-eval mode (see plots/bivariate
+            # _histograms.py: ``cbar.add_lines(cs1)``). Without it the shared
+            # intercomp colorbar is a bare gradient with no level cues.
+            if shared_target_cs is None and isinstance(_result, tuple):
+                shared_target_cs = _result[2]
 
         # Hide surplus axes in the last row.
         for idx in range(n_models, n_panels):
@@ -302,6 +319,8 @@ def intercompare_multivariate(models: list[Path], labels: list[str], out_root: P
         cbar.ax.xaxis.set_major_formatter(mticker.LogFormatterMathtext())
         cbar.set_label("Density (log scale)", fontsize=int(round(11 * font_scale)))
         cbar.ax.tick_params(labelsize=int(round(9 * font_scale)))
+        if shared_target_cs is not None:
+            cbar.add_lines(shared_target_cs)
         font_scale = max(1.0, n_panels**0.4)
 
         if var_x and var_y:

--- a/src/swissclim_evaluations/metrics/multivariate.py
+++ b/src/swissclim_evaluations/metrics/multivariate.py
@@ -67,6 +67,7 @@ def run(
         return
 
     bins = int(cfg.get("bins", 100))
+    coriolis_parameter = float(cfg.get("coriolis_parameter", 1.0e-4))
 
     # If mode is members, produce per-member plots
     if mode == "members" and "ensemble" in ds_prediction.dims:
@@ -86,6 +87,7 @@ def run(
                 out_root,
                 bins=bins,
                 ensemble_token=ens_token,
+                coriolis_parameter=coriolis_parameter,
             )
     else:
         ens_token = ensemble_mode_to_token(mode)
@@ -96,4 +98,5 @@ def run(
             out_root,
             bins=bins,
             ensemble_token=ens_token,
+            coriolis_parameter=coriolis_parameter,
         )

--- a/src/swissclim_evaluations/metrics/multivariate.py
+++ b/src/swissclim_evaluations/metrics/multivariate.py
@@ -41,6 +41,26 @@ def run(
         if "ensemble" in ds_target.dims:
             ds_t_run = ds_target.mean(dim="ensemble", keep_attrs=True)
 
+    elif mode == "pooled" and "ensemble" in ds_prediction.dims:
+        # Stack ensemble with a sample dimension so downstream flatten() treats
+        # all ensemble members as independent samples (explicit pooling).
+        non_ens_dims = [d for d in ds_prediction.dims if d != "ensemble"]
+        sample_dim = next(
+            (d for d in ("init_time", "time", "lead_time") if d in non_ens_dims),
+            non_ens_dims[0] if non_ens_dims else None,
+        )
+        if sample_dim is None:
+            raise ValueError(
+                "Pooled ensemble mode requires at least one non-ensemble dimension to stack "
+                f"over, but only found: {tuple(ds_prediction.dims)!r}"
+            )
+        ds_p_run = ds_prediction.stack(pooled_sample=("ensemble", sample_dim))
+        ds_t_run = (
+            ds_target.stack(pooled_sample=("ensemble", sample_dim))
+            if "ensemble" in ds_target.dims
+            else ds_target
+        )
+
     # Bivariate histograms
     bivariate_pairs = cfg.get("bivariate_pairs")
     if not bivariate_pairs:
@@ -68,8 +88,6 @@ def run(
                 ensemble_token=ens_token,
             )
     else:
-        # mean mode: ds_p_run is already reduced above.
-        # pooled mode: pass full dataset; the plotter flattens all dims.
         ens_token = ensemble_mode_to_token(mode)
         calculate_and_plot_bivariate_histograms(
             ds_p_run,

--- a/src/swissclim_evaluations/metrics/multivariate.py
+++ b/src/swissclim_evaluations/metrics/multivariate.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import xarray as xr
+
+from ..helpers import ensemble_mode_to_token, resolve_ensemble_mode
+from ..plots.bivariate_histograms import calculate_and_plot_bivariate_histograms
+
+
+def run(
+    ds_target: xr.Dataset,
+    ds_prediction: xr.Dataset,
+    out_root: Path,
+    metrics_cfg: dict[str, Any] | None,
+    ensemble_mode: str | None = None,
+) -> None:
+    """Compute and write multivariate metrics (Bivariate Histograms).
+
+    Args:
+        ds_target: Target/reference dataset.
+        ds_prediction: Prediction dataset.
+        out_root: Root output directory.
+        metrics_cfg: Full ``metrics`` config dict (``metrics_cfg["multivariate"]``
+            is read for ``bivariate_pairs`` and ``bins``).
+        ensemble_mode: Resolved ensemble handling mode (``mean`` / ``pooled`` /
+            ``members``). Falls back to module default (``mean``) if ``None``.
+    """
+    cfg = (metrics_cfg or {}).get("multivariate", {})
+
+    # Resolve ensemble mode
+    mode = resolve_ensemble_mode("multivariate", ensemble_mode, ds_target, ds_prediction)
+
+    # Handle ensemble dimension according to mode
+    ds_p_run = ds_prediction
+    ds_t_run = ds_target
+
+    if "ensemble" in ds_prediction.dims and mode == "mean":
+        ds_p_run = ds_prediction.mean(dim="ensemble", keep_attrs=True)
+        if "ensemble" in ds_target.dims:
+            ds_t_run = ds_target.mean(dim="ensemble", keep_attrs=True)
+
+    # Bivariate histograms
+    bivariate_pairs = cfg.get("bivariate_pairs")
+    if not bivariate_pairs:
+        return
+
+    bins = int(cfg.get("bins", 100))
+
+    # If mode is members, produce per-member plots
+    if mode == "members" and "ensemble" in ds_prediction.dims:
+        n_members = ds_prediction.sizes["ensemble"]
+        for m in range(n_members):
+            ds_p_mem = ds_prediction.isel(ensemble=m, drop=True)
+            if "ensemble" in ds_target.dims:
+                ds_t_mem = ds_target.isel(ensemble=m, drop=True)
+            else:
+                ds_t_mem = ds_target
+
+            ens_token = ensemble_mode_to_token(mode, member_index=m)
+            calculate_and_plot_bivariate_histograms(
+                ds_p_mem,
+                ds_t_mem,
+                bivariate_pairs,
+                out_root,
+                bins=bins,
+                ensemble_token=ens_token,
+            )
+    else:
+        # mean mode: ds_p_run is already reduced above.
+        # pooled mode: pass full dataset; the plotter flattens all dims.
+        ens_token = ensemble_mode_to_token(mode)
+        calculate_and_plot_bivariate_histograms(
+            ds_p_run,
+            ds_t_run,
+            bivariate_pairs,
+            out_root,
+            bins=bins,
+            ensemble_token=ens_token,
+        )

--- a/src/swissclim_evaluations/metrics/ssim.py
+++ b/src/swissclim_evaluations/metrics/ssim.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import xarray as xr
+from skimage.metrics import structural_similarity as ssim
+
+from .. import console as c
+from ..dask_utils import compute_jobs
+from ..helpers import (
+    build_output_filename,
+    ensemble_mode_to_token,
+    resolve_ensemble_mode,
+)
+
+
+def calculate_ssim(
+    ds_target: xr.Dataset,
+    ds_prediction: xr.Dataset,
+    sigma: float = 1.5,
+    K1: float = 0.01,
+    K2: float = 0.03,
+    gaussian_weights: bool = True,
+    use_sample_covariance: bool = True,
+) -> pd.DataFrame:
+    """Calculate SSIM for each variable.
+
+    SSIM is calculated for each 2-D spatial slice (lat/lon) and averaged over
+    all other dimensions (time, level, etc.).
+
+    Args:
+        ds_target: Target/reference dataset.
+        ds_prediction: Prediction dataset.
+        sigma: Standard deviation for the Gaussian kernel.
+        K1: Algorithm constant (luminance).
+        K2: Algorithm constant (contrast).
+        gaussian_weights: If ``True``, use Gaussian weighting.
+        use_sample_covariance: If ``True``, normalize covariance with N-1.
+
+    Returns:
+        DataFrame indexed by variable with a single ``SSIM`` column.
+    """
+    variables = list(ds_target.data_vars)
+    metrics_dict: dict[str, dict[str, float]] = {}
+
+    # 1. First pass: Collect lazy min/max computations for all variables
+    range_jobs = []
+    valid_vars = []
+
+    for var in variables:
+        if var not in ds_prediction:
+            continue
+
+        da_target = ds_target[var]
+        da_prediction = ds_prediction[var]
+
+        # Identify spatial dimensions
+        dims = list(da_target.dims)
+        spatial_dims = [d for d in dims if d in ["latitude", "longitude", "lat", "lon"]]
+
+        if len(spatial_dims) != 2:
+            continue
+
+        valid_vars.append(var)
+
+        # Calculate global data range for the variable
+        t_min_lazy = da_target.min(skipna=True)
+        t_max_lazy = da_target.max(skipna=True)
+        p_min_lazy = da_prediction.min(skipna=True)
+        p_max_lazy = da_prediction.max(skipna=True)
+
+        range_jobs.append(
+            {
+                "t_min": t_min_lazy,
+                "t_max": t_max_lazy,
+                "p_min": p_min_lazy,
+                "p_max": p_max_lazy,
+                "var": var,
+            }
+        )
+
+    if not range_jobs:
+        return pd.DataFrame()
+
+    # Compute ranges in batch
+    compute_jobs(
+        range_jobs,
+        key_map={
+            "t_min": "t_min_res",
+            "t_max": "t_max_res",
+            "p_min": "p_min_res",
+            "p_max": "p_max_res",
+        },
+        desc="Computing ranges",
+    )
+
+    # 2. Second pass: Create SSIM lazy objects using computed ranges
+    ssim_jobs = []
+
+    for job in range_jobs:
+        var = job["var"]
+        t_min = float(job["t_min_res"])
+        t_max = float(job["t_max_res"])
+        p_min = float(job["p_min_res"])
+        p_max = float(job["p_max_res"])
+
+        data_range = max(t_max, p_max) - min(t_min, p_min)
+        if data_range == 0:
+            data_range = 1.0
+
+        da_target = ds_target[var]
+        da_prediction = ds_prediction[var]
+
+        # Re-identify spatial dims (safe as we filtered already)
+        dims = list(da_target.dims)
+        spatial_dims = [d for d in dims if d in ["latitude", "longitude", "lat", "lon"]]
+
+        def _ssim_wrapper(t, p, data_range=data_range):
+            return ssim(
+                t,
+                p,
+                data_range=data_range,
+                gaussian_weights=gaussian_weights,
+                sigma=sigma,
+                use_sample_covariance=use_sample_covariance,
+                K1=K1,
+                K2=K2,
+            )
+
+        # Apply SSIM over spatial dimensions
+        ssim_da = xr.apply_ufunc(
+            _ssim_wrapper,
+            da_target,
+            da_prediction,
+            input_core_dims=[spatial_dims, spatial_dims],
+            output_core_dims=[[]],
+            vectorize=True,
+            dask="parallelized",
+            output_dtypes=[float],
+        )
+
+        # Average SSIM over all non-spatial dimensions
+        mean_ssim_lazy = ssim_da.mean(skipna=True)
+
+        ssim_jobs.append({"ssim_mean": mean_ssim_lazy, "var": var})
+
+    # Compute SSIM means in batch
+    compute_jobs(
+        ssim_jobs,
+        key_map={"ssim_mean": "ssim_res"},
+        desc="Computing SSIM metrics",
+    )
+
+    # 3. Populate results
+    for job in ssim_jobs:
+        var = job["var"]
+        val = float(job["ssim_res"])
+        metrics_dict[var] = {"SSIM": val}
+
+    return pd.DataFrame.from_dict(metrics_dict, orient="index")
+
+
+def run(
+    ds_target: xr.Dataset,
+    ds_prediction: xr.Dataset,
+    out_root: Path,
+    metrics_cfg: dict[str, Any] | None,
+    ensemble_mode: str | None = None,
+) -> None:
+    """Compute and write SSIM metrics CSVs.
+
+    Args:
+        ds_target: Target/reference dataset.
+        ds_prediction: Prediction dataset.
+        out_root: Root output directory. A ``ssim/`` sub-folder is created.
+        metrics_cfg: Full ``metrics`` config dict (reads ``metrics_cfg["ssim"]``
+            for ``sigma``, ``K1``, ``K2``, ``gaussian_weights``,
+            ``use_sample_covariance``).
+        ensemble_mode: Resolved ensemble handling mode.
+    """
+    cfg = (metrics_cfg or {}).get("ssim", {})
+
+    # Extract SSIM parameters
+    sigma = float(cfg.get("sigma", 1.5))
+    K1 = float(cfg.get("K1", 0.01))
+    K2 = float(cfg.get("K2", 0.03))
+    gaussian_weights = bool(cfg.get("gaussian_weights", True))
+    use_sample_covariance = bool(cfg.get("use_sample_covariance", True))
+
+    # Resolve ensemble mode
+    mode = resolve_ensemble_mode("ssim", ensemble_mode, ds_target, ds_prediction)
+
+    # Helper to save output
+    def _save_output(df: pd.DataFrame, ens_token: str | None) -> None:
+        if df.empty:
+            return
+
+        # Calculate average SSIM across variables
+        avg_score = df["SSIM"].mean()
+        summary_row = pd.DataFrame({"SSIM": [avg_score]}, index=["AVERAGE_SSIM"])
+        df_final = pd.concat([df, summary_row])
+
+        filename = build_output_filename(
+            metric="ssim", qualifier="ssim", ensemble=ens_token, ext="csv"
+        )
+        out_path = out_root / "ssim" / filename
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        df_final.to_csv(out_path, index_label="variable")
+        c.info(f"[ssim] saved {out_path}")
+
+    # Handle ensemble dimension
+    if "ensemble" in ds_prediction.dims and mode == "mean":
+        ds_prediction = ds_prediction.mean(dim="ensemble")
+        if "ensemble" in ds_target.dims:
+            ds_target = ds_target.mean(dim="ensemble")
+
+    if mode == "members" and "ensemble" in ds_prediction.dims:
+        # Per-member outputs
+        n_members = ds_prediction.sizes["ensemble"]
+        for m in range(n_members):
+            ds_p_mem = ds_prediction.isel(ensemble=m, drop=True)
+            if "ensemble" in ds_target.dims:
+                ds_t_mem = ds_target.isel(ensemble=m, drop=True)
+            else:
+                ds_t_mem = ds_target
+
+            df = calculate_ssim(
+                ds_t_mem,
+                ds_p_mem,
+                sigma=sigma,
+                K1=K1,
+                K2=K2,
+                gaussian_weights=gaussian_weights,
+                use_sample_covariance=use_sample_covariance,
+            )
+            ens_token = ensemble_mode_to_token(mode, member_index=m)
+            _save_output(df, ens_token)
+
+    elif mode == "pooled" and "ensemble" in ds_prediction.dims:
+        # Stack ensemble into the sample dimension
+        sample_dim = (
+            "init_time"
+            if "init_time" in ds_prediction.dims
+            else (
+                "lead_time"
+                if "lead_time" in ds_prediction.dims
+                else ("time" if "time" in ds_prediction.dims else list(ds_prediction.dims)[0])
+            )
+        )
+        ds_prediction_stacked = ds_prediction.stack(pooled_sample=("ensemble", sample_dim))
+        ds_target_stacked = ds_target
+        if "ensemble" in ds_target.dims:
+            ds_target_stacked = ds_target.stack(pooled_sample=("ensemble", sample_dim))
+
+        df = calculate_ssim(
+            ds_target_stacked,
+            ds_prediction_stacked,
+            sigma=sigma,
+            K1=K1,
+            K2=K2,
+            gaussian_weights=gaussian_weights,
+            use_sample_covariance=use_sample_covariance,
+        )
+        ens_token = ensemble_mode_to_token(mode)
+        _save_output(df, ens_token)
+
+    else:
+        # Single output (mean or no ensemble)
+        df = calculate_ssim(
+            ds_target,
+            ds_prediction,
+            sigma=sigma,
+            K1=K1,
+            K2=K2,
+            gaussian_weights=gaussian_weights,
+            use_sample_covariance=use_sample_covariance,
+        )
+        ens_token = ensemble_mode_to_token(mode)
+        _save_output(df, ens_token)

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -1235,11 +1235,16 @@ def plot_bivariate_histogram(
     # ── Physical-constraint overlays ─────────────────────────────────────────
     final_xlim = ax.get_xlim()
     final_ylim = ax.get_ylim()
+    # Use axis limits (not bin edges) so curves and fills extend to the full
+    # visible area — bin edges end at the data range, but the plot is zoomed
+    # out 25% beyond that, leaving an unshaded/truncated gap at the edges.
+    axis_bins_x = np.array([final_xlim[0], final_xlim[1]])
+    axis_bins_y = np.array([final_ylim[0], final_ylim[1]])
     constraints = _get_physical_constraints(
         var_x,
         var_y,
-        bins_x,
-        bins_y,
+        axis_bins_x,
+        axis_bins_y,
         level_hpa=level_hpa,
     )
     constraint_entries = _draw_physical_constraints(

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -112,6 +112,13 @@ def _get_physical_constraints(
         Bin-edge arrays produced by the histogram step.
     """
     constraints: list[dict] = []
+
+    # Physical overlays are only meaningful at 500 hPa — at other levels the
+    # saturation-curve shape / geostrophic slope differ enough that the overlay
+    # would either lie off-screen or be misleading.
+    if level_hpa is None or not np.isclose(float(level_hpa), 500.0):
+        return constraints
+
     lx, ly = var_x.lower(), var_y.lower()
 
     is_temp_x = "temperature" in lx
@@ -600,10 +607,11 @@ def _plot_bivariate_per_lead_grid(
     # ── Grid layout ───────────────────────────────────────────────────────────
     cols = min(3, n_leads)
     rows = int(np.ceil(n_leads / cols))
+    # Extra height for the shared horizontal colorbar below the grid.
     fig, axs = plt.subplots(
         rows,
         cols,
-        figsize=(6 * cols, 5 * rows),
+        figsize=(6 * cols, 6 * rows + 1),
         dpi=150,
         constrained_layout=True,
     )
@@ -654,6 +662,8 @@ def _plot_bivariate_per_lead_grid(
                 show_colorbar=False,
                 show_legend=(i == 0),
             )
+        # Force square subplot regardless of data unit scales.
+        ax.set_box_aspect(1)
         # Show only lead-time label as subplot title (e.g. "+6h").
         ax.set_title(lead_label, fontsize=10)
         last_i = i

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -739,15 +739,25 @@ def calculate_and_plot_bivariate_histograms(
             pred_x_sel = pred_x.sel(level=level_hpa) if x_has_level else pred_x
             pred_y_sel = pred_y.sel(level=level_hpa) if y_has_level else pred_y
 
-            da_x = pred_x_sel.data.flatten()
-            da_y = pred_y_sel.data.flatten()
+            # Select matching level for target variables when available
+            targ_x_sel = targ_x.sel(level=level_hpa) if "level" in targ_x.dims else targ_x
+            targ_y_sel = targ_y.sel(level=level_hpa) if "level" in targ_y.dims else targ_y
 
-            # Compute min/max lazily to determine range and handle NaNs
-            min_x_lazy = da.nanmin(da_x)
-            max_x_lazy = da.nanmax(da_x)
-            min_y_lazy = da.nanmin(da_y)
-            max_y_lazy = da.nanmax(da_y)
+            # Flatten prediction and target data to 1D Dask arrays
+            da_x_pred = pred_x_sel.data.flatten()
+            da_y_pred = pred_y_sel.data.flatten()
+            da_x_targ = targ_x_sel.data.flatten()
+            da_y_targ = targ_y_sel.data.flatten()
 
+            # Combine prediction and target for range computation
+            da_x_combined = da.concatenate([da_x_pred, da_x_targ])
+            da_y_combined = da.concatenate([da_y_pred, da_y_targ])
+
+            # Compute min/max lazily over both prediction and target, handling NaNs
+            min_x_lazy = da.nanmin(da_x_combined)
+            max_x_lazy = da.nanmax(da_x_combined)
+            min_y_lazy = da.nanmin(da_y_combined)
+            max_y_lazy = da.nanmax(da_y_combined)
             range_jobs.append(
                 {
                     "min_x": min_x_lazy,

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -652,13 +652,10 @@ def _plot_bivariate_per_lead_grid(
                 xlabel=_get_label(ds_prediction[var_x], var_x),
                 ylabel=_get_label(ds_prediction[var_y], var_y),
                 show_colorbar=False,
+                show_legend=(i == 0),
             )
-        # Replace the per-subplot title set inside plot_bivariate_histogram with
-        # one that also carries the lead-time label.
-        ax.set_title(
-            f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}\n{lead_label}",
-            fontsize=10,
-        )
+        # Show only lead-time label as subplot title (e.g. "+6h").
+        ax.set_title(lead_label, fontsize=10)
         last_i = i
 
     # ── Hide any surplus subplots beyond n_leads ──────────────────────────────
@@ -675,7 +672,7 @@ def _plot_bivariate_per_lead_grid(
         location="bottom",
         pad=0.04,
         fraction=0.04,
-        shrink=0.8,
+        shrink=1.6,
     )
     cbar.ax.xaxis.set_major_locator(mticker.LogLocator())
     cbar.ax.xaxis.set_major_formatter(mticker.LogFormatterMathtext())
@@ -1055,6 +1052,7 @@ def plot_bivariate_histogram(
     xlim: tuple[float, float] | None = None,
     ylim: tuple[float, float] | None = None,
     show_colorbar: bool = True,
+    show_legend: bool = True,
 ) -> plt.Axes:
     """Plot bivariate histograms for two models/datasets.
 
@@ -1272,13 +1270,14 @@ def plot_bivariate_histogram(
         handles.append(artist)
         labels.append(lbl)
 
-    ax.legend(
-        handles=handles,
-        labels=labels,
-        loc="upper right",
-        handler_map={tuple: HandlerTuple(ndivide=None, pad=0)},
-        fontsize="small",
-        framealpha=0.85,
-    )
+    if show_legend:
+        ax.legend(
+            handles=handles,
+            labels=labels,
+            loc="upper right",
+            handler_map={tuple: HandlerTuple(ndivide=None, pad=0)},
+            fontsize="small",
+            framealpha=0.85,
+        )
 
     return ax

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -1,0 +1,1225 @@
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import dask.array as da
+import matplotlib.colors as mcolors
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from matplotlib.colors import LogNorm
+from matplotlib.legend_handler import HandlerTuple
+from matplotlib.lines import Line2D
+
+from .. import console as c
+from ..dask_utils import compute_jobs
+from ..helpers import format_variable_name, get_variable_units
+
+
+def _is_geopotential_height(name: str) -> bool:
+    return "geopotential_height" in str(name).lower() and "gradient" not in str(name).lower()
+
+
+def _is_geopotential_height_gradient(name: str) -> bool:
+    return "geopotential_height_gradient" in str(name).lower()
+
+
+def _is_wind_speed(name: str) -> bool:
+    return "wind_speed" in str(name).lower()
+
+
+def _is_geostrophic_gradient_pair(var_x: str, var_y: str) -> bool:
+    lx = str(var_x).lower()
+    ly = str(var_y).lower()
+    return ("geopotential_height_gradient" in lx and "wind_speed" in ly) or (
+        "geopotential_height_gradient" in ly and "wind_speed" in lx
+    )
+
+
+def _format_level_suffix(level_hpa: float | None) -> str:
+    if level_hpa is None:
+        return ""
+    if float(level_hpa).is_integer():
+        return f"_level{int(level_hpa)}"
+    return f"_level{level_hpa:g}"
+
+
+def _get_label(da: xr.DataArray, var_name: str) -> str:
+    """Get a formatted label with unit for a variable from DataArray attributes."""
+    name = format_variable_name(var_name)
+    unit = get_variable_units(da, var_name)
+    if unit:
+        return f"{name} [{unit}]"
+    return name
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Physical-constraint overlay helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _q_sat_at_pressure(T_K: np.ndarray, P_Pa: float = 50000.0) -> np.ndarray:
+    """Saturation specific humidity [kg kg⁻¹] via Bolton (1980).
+
+    Uses the standard Magnus/Tetens saturation-vapour-pressure formula valid
+    for temperatures in the range roughly −40 °C to +60 °C.
+
+    Parameters
+    ----------
+    T_K : array_like
+        Temperature in Kelvin.
+    P_Pa : float
+        Ambient pressure in Pa (default: 50 000 Pa = 500 hPa).
+    """
+    epsilon = 0.6219  # Rd / Rv ratio
+    T_C = np.asarray(T_K, dtype=float) - 273.15
+    # Bolton (1980) saturation vapour pressure [Pa]
+    e_s = 611.2 * np.exp(17.67 * T_C / (T_C + 243.5))
+    e_s = np.clip(e_s, 0.0, 0.99 * P_Pa)  # prevent q_sat → ∞
+    return epsilon * e_s / (P_Pa - (1.0 - epsilon) * e_s)
+
+
+def _get_physical_constraints(
+    var_x: str,
+    var_y: str,
+    bins_x: np.ndarray,
+    bins_y: np.ndarray,
+    level_hpa: float | None = None,
+) -> list[dict]:
+    """Return a list of physical-constraint specs for the given variable pair.
+
+    Each spec is a plain dict that drives :func:`_draw_physical_constraints`.
+    Currently handled pairs:
+
+    * **temperature × specific_humidity** — Clausius–Clapeyron saturation curve
+      at 500 hPa (Bolton 1980).  The supersaturated region and q < 0 are shaded.
+        * **geopotential_height_gradient × wind_speed** — geostrophic reference
+            line plus hard lower bound wind speed >= 0.
+
+    Parameters
+    ----------
+    var_x, var_y : str
+        Variable names as they appear in the dataset.
+    bins_x, bins_y : np.ndarray
+        Bin-edge arrays produced by the histogram step.
+    """
+    constraints: list[dict] = []
+
+    # Draw physical overlays only for 500 hPa views.
+    if level_hpa is None or not np.isclose(float(level_hpa), 500.0):
+        return constraints
+    lx, ly = var_x.lower(), var_y.lower()
+
+    is_temp_x = "temperature" in lx
+    is_temp_y = "temperature" in ly
+    is_q_x = "specific_humidity" in lx
+    is_q_y = "specific_humidity" in ly
+    is_zgrad_x = "geopotential_height_gradient" in lx
+    is_zgrad_y = "geopotential_height_gradient" in ly
+    is_ws_x = "wind_speed" in lx
+    is_ws_y = "wind_speed" in ly
+
+    # ── Temperature vs Specific Humidity ────────────────────────────────────
+    # Physical upper bound: q ≤ q_sat(T) — Clausius–Clapeyron.
+    # Physical lower bound: q ≥ 0.
+    if (is_temp_x and is_q_y) or (is_q_x and is_temp_y):
+        if is_temp_x:  # temperature on x-axis, q on y-axis
+            T_arr = np.linspace(bins_x[0], bins_x[-1], 400)
+            q_sat = _q_sat_at_pressure(T_arr, P_Pa=50000.0)
+            constraints.append(
+                {
+                    "type": "curve",
+                    "value_x": T_arr,
+                    "value_y": q_sat,
+                    "fill_x": T_arr,
+                    "fill_y": q_sat,
+                    "fill": "above",
+                    "color": "#d62728",
+                    "lw": 2.0,
+                    "ls": "--",
+                    "label": r"$q_\mathrm{sat}(T)$ — Bolton (1980), 500 hPa",
+                    "fill_alpha": 0.13,
+                    "fill_color": "#d62728",
+                    "fill_hatch": "///",
+                    "fill_label": "Supersaturated (unphysical)",
+                }
+            )
+            constraints.append(
+                {
+                    "type": "hline",
+                    "value": 0.0,
+                    "fill": "below",
+                    "color": "#8c1515",
+                    "lw": 1.5,
+                    "ls": ":",
+                    "label": "$q = 0$",
+                    "fill_alpha": 0.10,
+                    "fill_color": "#8c1515",
+                    "fill_hatch": "\\\\\\\\",
+                    "fill_label": "$q < 0$ (unphysical)",
+                }
+            )
+        else:  # q on x-axis, temperature on y-axis
+            T_arr = np.linspace(bins_y[0], bins_y[-1], 400)
+            q_sat = _q_sat_at_pressure(T_arr, P_Pa=50000.0)
+            constraints.append(
+                {
+                    "type": "curve",
+                    "value_x": q_sat,
+                    "value_y": T_arr,
+                    "fill_x": q_sat,
+                    "fill_y": T_arr,
+                    "fill": "right",
+                    "color": "#d62728",
+                    "lw": 2.0,
+                    "ls": "--",
+                    "label": r"$q_\mathrm{sat}(T)$ — Bolton (1980), 500 hPa",
+                    "fill_alpha": 0.13,
+                    "fill_color": "#d62728",
+                    "fill_hatch": "///",
+                    "fill_label": "Supersaturated (unphysical)",
+                }
+            )
+            constraints.append(
+                {
+                    "type": "vline",
+                    "value": 0.0,
+                    "fill": "left",
+                    "color": "#8c1515",
+                    "lw": 1.5,
+                    "ls": ":",
+                    "label": "$q = 0$",
+                    "fill_alpha": 0.10,
+                    "fill_color": "#8c1515",
+                    "fill_hatch": "\\\\\\\\",
+                    "fill_label": "$q < 0$ (unphysical)",
+                }
+            )
+
+    # ── Geopotential Height Gradient vs Wind Speed ──────────────────────────
+    # Geostrophic balance: U_g = (g / f) * |∇Z|
+    # Plotted as a diagonal reference line through the origin.
+    # Using representative mid-latitude |f| = 1e-4 s⁻¹ and g = 9.81 m s⁻².
+    if (is_zgrad_x or is_zgrad_y) and (is_ws_x or is_ws_y):
+        g = 9.81
+        f_abs = 1.0e-4  # mid-latitude Coriolis parameter, s⁻¹
+        slope = g / f_abs  # ≈ 98 100  (m s⁻¹) / (m m⁻¹)
+
+        if is_zgrad_x and is_ws_y:
+            # x = |∇Z|  [m m⁻¹],  y = wind speed  [m s⁻¹]
+            x_arr = np.linspace(max(bins_x[0], 0.0), bins_x[-1], 400)
+            y_arr = slope * x_arr
+            constraints.append(
+                {
+                    "type": "curve",
+                    "value_x": x_arr,
+                    "value_y": y_arr,
+                    "color": "#ff7f0e",
+                    "lw": 2.0,
+                    "ls": "--",
+                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$, "
+                    r"$f=10^{-4}\,\mathrm{s}^{-1}$",
+                }
+            )
+        elif is_zgrad_y and is_ws_x:
+            # x = wind speed  [m s⁻¹],  y = |∇Z|  [m m⁻¹]
+            x_arr = np.linspace(max(bins_x[0], 0.0), bins_x[-1], 400)
+            y_arr = x_arr / slope
+            constraints.append(
+                {
+                    "type": "curve",
+                    "value_x": x_arr,
+                    "value_y": y_arr,
+                    "color": "#ff7f0e",
+                    "lw": 2.0,
+                    "ls": "--",
+                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$, "
+                    r"$f=10^{-4}\,\mathrm{s}^{-1}$",
+                }
+            )
+
+        # Wind speed ≥ 0 hard bound
+        if is_ws_y:
+            constraints.append(
+                {
+                    "type": "hline",
+                    "value": 0.0,
+                    "fill": "below",
+                    "color": "#d62728",
+                    "lw": 1.5,
+                    "ls": ":",
+                    "label": "Wind speed $= 0$",
+                    "fill_alpha": 0.10,
+                    "fill_color": "#d62728",
+                    "fill_hatch": "\\\\\\\\",
+                    "fill_label": "Wind speed $< 0$ (unphysical)",
+                }
+            )
+        else:
+            constraints.append(
+                {
+                    "type": "vline",
+                    "value": 0.0,
+                    "fill": "left",
+                    "color": "#d62728",
+                    "lw": 1.5,
+                    "ls": ":",
+                    "label": "Wind speed $= 0$",
+                    "fill_alpha": 0.10,
+                    "fill_color": "#d62728",
+                    "fill_hatch": "\\\\\\\\",
+                    "fill_label": "Wind speed $< 0$ (unphysical)",
+                }
+            )
+
+    return constraints
+
+
+def _draw_physical_constraints(
+    ax: plt.Axes,
+    constraints: list[dict],
+    x_range: tuple[float, float],
+    y_range: tuple[float, float],
+) -> list[tuple]:
+    """Draw physical-constraint lines and shaded regions on *ax*.
+
+    Returns a list of ``(artist, label)`` pairs to be appended to the legend.
+    """
+    x_min, x_max = x_range
+    y_min, y_max = y_range
+    legend_entries: list[tuple] = []
+    fill_labels_seen: set[str] = set()
+
+    for spec in constraints:
+        ctype = spec["type"]
+        color = spec.get("color", "#d62728")
+        lw = spec.get("lw", 1.5)
+        ls = spec.get("ls", "--")
+        label = spec.get("label", "")
+        fill_side = spec.get("fill", None)
+        fill_alpha = spec.get("fill_alpha", 0.12)
+        fill_color = spec.get("fill_color", color)
+        fill_hatch = spec.get("fill_hatch", None)
+        fill_label = spec.get("fill_label", None)
+
+        if ctype == "hline":
+            val = float(spec["value"])
+            (line,) = ax.plot(
+                [x_min, x_max],
+                [val, val],
+                color=color,
+                lw=lw,
+                ls=ls,
+                zorder=6,
+                label=label,
+            )
+            legend_entries.append((line, label))
+            if fill_side == "above":
+                ax.fill_between(
+                    [x_min, x_max],
+                    val,
+                    y_max,
+                    color=fill_color,
+                    alpha=fill_alpha,
+                    hatch=fill_hatch,
+                    zorder=4,
+                    linewidth=0,
+                )
+            elif fill_side == "below":
+                ax.fill_between(
+                    [x_min, x_max],
+                    y_min,
+                    val,
+                    color=fill_color,
+                    alpha=fill_alpha,
+                    hatch=fill_hatch,
+                    zorder=4,
+                    linewidth=0,
+                )
+
+        elif ctype == "vline":
+            val = float(spec["value"])
+            (line,) = ax.plot(
+                [val, val],
+                [y_min, y_max],
+                color=color,
+                lw=lw,
+                ls=ls,
+                zorder=6,
+                label=label,
+            )
+            legend_entries.append((line, label))
+            if fill_side == "right":
+                ax.fill_betweenx(
+                    [y_min, y_max],
+                    val,
+                    x_max,
+                    color=fill_color,
+                    alpha=fill_alpha,
+                    hatch=fill_hatch,
+                    zorder=4,
+                    linewidth=0,
+                )
+            elif fill_side == "left":
+                ax.fill_betweenx(
+                    [y_min, y_max],
+                    x_min,
+                    val,
+                    color=fill_color,
+                    alpha=fill_alpha,
+                    hatch=fill_hatch,
+                    zorder=4,
+                    linewidth=0,
+                )
+
+        elif ctype == "curve":
+            xs = np.asarray(spec["value_x"])
+            ys = np.asarray(spec["value_y"])
+            (line,) = ax.plot(xs, ys, color=color, lw=lw, ls=ls, zorder=6, label=label)
+            legend_entries.append((line, label))
+            fill_xs = np.asarray(spec.get("fill_x", xs))
+            fill_ys = np.asarray(spec.get("fill_y", ys))
+            if fill_side == "above":
+                ax.fill_between(
+                    fill_xs,
+                    fill_ys,
+                    y_max,
+                    color=fill_color,
+                    alpha=fill_alpha,
+                    hatch=fill_hatch,
+                    zorder=4,
+                    linewidth=0,
+                )
+            elif fill_side == "below":
+                ax.fill_between(
+                    fill_xs,
+                    y_min,
+                    fill_ys,
+                    color=fill_color,
+                    alpha=fill_alpha,
+                    hatch=fill_hatch,
+                    zorder=4,
+                    linewidth=0,
+                )
+            elif fill_side == "right":
+                ax.fill_betweenx(
+                    fill_ys,
+                    fill_xs,
+                    x_max,
+                    color=fill_color,
+                    alpha=fill_alpha,
+                    hatch=fill_hatch,
+                    zorder=4,
+                    linewidth=0,
+                )
+            elif fill_side == "left":
+                ax.fill_betweenx(
+                    fill_ys,
+                    x_min,
+                    fill_xs,
+                    color=fill_color,
+                    alpha=fill_alpha,
+                    hatch=fill_hatch,
+                    zorder=4,
+                    linewidth=0,
+                )
+
+        # Add shaded-region label (deduplicated)
+        if fill_label and fill_label not in fill_labels_seen:
+            fill_labels_seen.add(fill_label)
+            patch = mpatches.Patch(
+                color=fill_color,
+                alpha=fill_alpha + 0.1,
+                hatch=fill_hatch,
+                label=fill_label,
+                linewidth=0,
+            )
+            legend_entries.append((patch, fill_label))
+
+    return legend_entries
+
+
+def _plot_bivariate_per_lead_grid(
+    ds_prediction: xr.Dataset,
+    ds_target: xr.Dataset | None,
+    var_x: str,
+    var_y: str,
+    xedges: np.ndarray,
+    yedges: np.ndarray,
+    out_root: Path,
+    ensemble_token: str | None = None,
+    level_hpa: float | None = None,
+) -> None:
+    """Generate a per-lead-time grid of bivariate histograms for one variable pair.
+
+    Produces a single figure where each subplot corresponds to one lead time,
+    arranged in a grid of up to 3 columns.  All subplots share the same bin
+    edges (``xedges`` / ``yedges``) so that densities are directly comparable
+    across lead times.
+
+    **Dask contract**: All lazy histogram objects for every lead time (both
+    prediction and target) are collected into a single :func:`compute_jobs`
+    call.  No per-lead ``compute()`` is issued, ensuring a single scheduler
+    round-trip.
+
+    Parameters
+    ----------
+    ds_prediction : xr.Dataset
+        Prediction dataset.  **Must** contain a ``lead_time`` dimension with
+        at least 2 values for this function to produce output.
+    ds_target : xr.Dataset or None
+        Reference/observation dataset.  If ``None`` the subplots show only
+        the prediction distribution (no filled ground-truth contours).
+    var_x : str
+        Variable name plotted on the x-axis.
+    var_y : str
+        Variable name plotted on the y-axis.
+    xedges : np.ndarray
+        Bin edges for the x-axis, pre-computed from the global data range.
+    yedges : np.ndarray
+        Bin edges for the y-axis, pre-computed from the global data range.
+    out_root : Path
+        Root output directory.  A ``multivariate/`` sub-folder is created
+        automatically.
+    ensemble_token : str or None
+        Optional token appended to the output filename
+        (e.g. ``ensmean``, ``ens0``).
+    level_hpa : float or None
+        Pressure-level value in hPa (e.g. ``500.0``) to select from 3-D
+        variables before slicing by lead time.  When ``None`` the full array
+        is used (2-D variable case).  The caller must pass the same value
+        that was used to compute ``xedges``/``yedges``.
+    """
+    # ── Guard: need multi-lead prediction ────────────────────────────────────
+    if "lead_time" not in ds_prediction[var_x].dims:
+        return
+    leads = ds_prediction["lead_time"].values
+    n_leads = len(leads)
+    if n_leads < 2:
+        return
+
+    # ── Pre-compute fill sentinels (out-of-range substitutes for NaN) ────────
+    fill_x = float(xedges[0]) - 1.0
+    fill_y = float(yedges[0]) - 1.0
+    range_x = [float(xedges[0]), float(xedges[-1])]
+    range_y = [float(yedges[0]), float(yedges[-1])]
+
+    # ── Build one lazy histogram job per lead time ────────────────────────────
+    # All lazy objects are collected here; a single compute_jobs call resolves
+    # the entire graph without repeated scheduler round-trips.
+    hist_jobs: list[dict] = []
+    for lt in leads:
+        # ── Prediction slice ──────────────────────────────────────────────────
+        # Apply level selection for 3-D variables before slicing by lead time.
+        _px = ds_prediction[var_x]
+        if level_hpa is not None and "level" in _px.dims:
+            _px = _px.sel(level=level_hpa)
+        da_xp = _px.sel(lead_time=lt).data.flatten()
+        _py = ds_prediction[var_y]
+        if level_hpa is not None and "level" in _py.dims:
+            _py = _py.sel(level=level_hpa)
+        da_yp = _py.sel(lead_time=lt).data.flatten()
+        da_xp = da.where(da.isnan(da_xp), fill_x, da_xp)
+        da_yp = da.where(da.isnan(da_yp), fill_y, da_yp)
+        h_pred_lazy, _, _ = da.histogram2d(
+            da_xp, da_yp, bins=[xedges, yedges], range=[range_x, range_y]
+        )
+
+        # ── Target slice (may lack lead_time dim — use full array in that case)
+        # Apply level selection first when dealing with 3-D target variables.
+        h_target_lazy = None
+        if ds_target is not None:
+            _tx = ds_target[var_x]
+            _ty = ds_target[var_y]
+            if level_hpa is not None:
+                if "level" in _tx.dims:
+                    _tx = _tx.sel(level=level_hpa)
+                if "level" in _ty.dims:
+                    _ty = _ty.sel(level=level_hpa)
+            if "lead_time" in _tx.dims:
+                da_xt = _tx.sel(lead_time=lt).data.flatten()
+            else:
+                da_xt = _tx.data.flatten()
+            if "lead_time" in _ty.dims:
+                da_yt = _ty.sel(lead_time=lt).data.flatten()
+            else:
+                da_yt = _ty.data.flatten()
+            da_xt = da.where(da.isnan(da_xt), fill_x, da_xt)
+            da_yt = da.where(da.isnan(da_yt), fill_y, da_yt)
+            h_target_lazy, _, _ = da.histogram2d(
+                da_xt, da_yt, bins=[xedges, yedges], range=[range_x, range_y]
+            )
+
+        hist_jobs.append(
+            {
+                "h_pred": h_pred_lazy,
+                "h_target": h_target_lazy,
+                "lt": lt,
+            }
+        )
+
+    # ── Single batch compute for all lead-time histograms ────────────────────
+    compute_jobs(
+        hist_jobs,
+        key_map={"h_pred": "hist_pred", "h_target": "hist_target"},
+        desc=f"Computing bivariate histograms by lead: {var_x} vs {var_y}",
+    )
+
+    # ── Grid layout ───────────────────────────────────────────────────────────
+    cols = min(3, n_leads)
+    rows = int(np.ceil(n_leads / cols))
+    fig, axs = plt.subplots(
+        rows,
+        cols,
+        figsize=(6 * cols, 5 * rows),
+        dpi=150,
+        constrained_layout=True,
+    )
+    axs_flat = np.atleast_1d(np.array(axs)).flatten()
+
+    last_i = 0
+    for i, job in enumerate(hist_jobs):
+        lt = job["lt"]
+        # Format lead-time label (timedelta64 → '+Nh', otherwise string)
+        if np.issubdtype(type(lt), np.timedelta64):
+            hours = int(lt / np.timedelta64(1, "h"))
+            lead_label = f"+{hours}h"
+        else:
+            lead_label = str(lt)
+
+        ax = axs_flat[i]
+        hist_pred = job.get("hist_pred")
+        hist_target = job.get("hist_target")
+
+        if hist_pred is None:
+            ax.set_title(f"Lead: {lead_label} (no data)")
+            ax.axis("off")
+            last_i = i
+            continue
+
+        # When target is unavailable, pass a zero array so plot_bivariate_histogram
+        # can still render the prediction contours without crashing.
+        if hist_target is None:
+            hist_target = np.zeros_like(hist_pred)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="Log scale: values of z <= 0 have been masked"
+            )
+            plot_bivariate_histogram(
+                hist_1=hist_pred,
+                hist_2=hist_target,
+                bins_x=xedges,
+                bins_y=yedges,
+                label_1="Model Prediction",
+                label_2="Ground Truth",
+                var_x=var_x,
+                var_y=var_y,
+                level_hpa=level_hpa,
+                ax=ax,
+                xlabel=_get_label(ds_prediction[var_x], var_x),
+                ylabel=_get_label(ds_prediction[var_y], var_y),
+            )
+        # Replace the per-subplot title set inside plot_bivariate_histogram with
+        # one that also carries the lead-time label.
+        ax.set_title(
+            f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}\n{lead_label}",
+            fontsize=10,
+        )
+        last_i = i
+
+    # ── Hide any surplus subplots beyond n_leads ──────────────────────────────
+    for j in range(last_i + 1, len(axs_flat)):
+        axs_flat[j].axis("off")
+
+    lev_title = f" @ {level_hpa:g} hPa" if level_hpa is not None else ""
+    fig.suptitle(
+        f"Bivariate Histograms by Lead Time — "
+        f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}{lev_title}",
+        fontsize=14,
+    )
+
+    # ── Save ──────────────────────────────────────────────────────────────────
+    suffix = f"_{ensemble_token}" if ensemble_token else ""
+    lev_sfx = _format_level_suffix(level_hpa)
+    out_dir = out_root / "multivariate"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_png = out_dir / f"bivariate_by_lead_{var_x}_{var_y}{lev_sfx}{suffix}.png"
+    fig.savefig(out_png, bbox_inches="tight")
+    plt.close(fig)
+    c.info(f"[multivariate] Saved per-lead-time bivariate grid: {out_png.name}")
+
+
+def calculate_and_plot_bivariate_histograms(
+    ds_prediction: xr.Dataset,
+    ds_target: xr.Dataset | None,
+    pairs: list[list[str]],
+    out_root: Path,
+    bins: int = 100,
+    ensemble_token: str | None = None,
+) -> None:
+    """Calculate and save bivariate histograms for specified pairs.
+
+    Also generates the plot immediately if target is available.
+
+    Args:
+        ds_prediction: Prediction dataset.
+        ds_target: Target/reference dataset. If None, pairs are skipped.
+        pairs: List of [var_x, var_y] pairs to plot.
+        out_root: Root output directory. A ``multivariate/`` sub-folder is
+            created automatically.
+        bins: Number of histogram bins along each axis.
+        ensemble_token: Optional token appended to output filenames
+            (e.g. ``ensmean``, ``ens0``).
+    """
+    plotted_pairs = []
+    skipped_pairs = []
+
+    # 1. First pass: Collect lazy min/max computations for all pairs
+    range_jobs = []
+
+    for i, pair in enumerate(pairs):
+        if len(pair) != 2:
+            continue
+        var_x, var_y = pair
+
+        # Check if variables exist in prediction dataset
+        if var_x not in ds_prediction or var_y not in ds_prediction:
+            skipped_pairs.append(f"{var_x} vs {var_y} (missing in prediction)")
+            continue
+
+        # Check if variables exist in target dataset
+        if ds_target is None:
+            skipped_pairs.append(f"{var_x} vs {var_y} (no target dataset)")
+            continue
+
+        if var_x not in ds_target or var_y not in ds_target:
+            skipped_pairs.append(f"{var_x} vs {var_y} (missing in target)")
+            continue
+
+        pred_x = ds_prediction[var_x]
+        pred_y = ds_prediction[var_y]
+        targ_x = ds_target[var_x]
+        targ_y = ds_target[var_y]
+
+        x_has_level = "level" in pred_x.dims
+        y_has_level = "level" in pred_y.dims
+
+        levels_to_process: list[float | None]
+        if x_has_level or y_has_level:
+            level_values: np.ndarray | None = None
+
+            def _merge_levels(level_arr: np.ndarray) -> None:
+                nonlocal level_values
+                if level_values is None:
+                    level_values = np.asarray(level_arr)
+                else:
+                    level_values = np.intersect1d(level_values, np.asarray(level_arr))
+
+            if x_has_level:
+                _merge_levels(pred_x["level"].values)
+            if "level" in targ_x.dims:
+                _merge_levels(targ_x["level"].values)
+            if y_has_level:
+                _merge_levels(pred_y["level"].values)
+            if "level" in targ_y.dims:
+                _merge_levels(targ_y["level"].values)
+
+            if level_values is None or len(level_values) == 0:
+                skipped_pairs.append(f"{var_x} vs {var_y} (no common levels)")
+                continue
+
+            levels_to_process = [float(v) for v in np.asarray(level_values, dtype=float)]
+        else:
+            levels_to_process = [None]
+
+        for level_hpa in levels_to_process:
+            pred_x_sel = pred_x.sel(level=level_hpa) if x_has_level else pred_x
+            pred_y_sel = pred_y.sel(level=level_hpa) if y_has_level else pred_y
+
+            da_x = pred_x_sel.data.flatten()
+            da_y = pred_y_sel.data.flatten()
+
+            # Compute min/max lazily to determine range and handle NaNs
+            min_x_lazy = da.nanmin(da_x)
+            max_x_lazy = da.nanmax(da_x)
+            min_y_lazy = da.nanmin(da_y)
+            max_y_lazy = da.nanmax(da_y)
+
+            range_jobs.append(
+                {
+                    "min_x": min_x_lazy,
+                    "max_x": max_x_lazy,
+                    "min_y": min_y_lazy,
+                    "max_y": max_y_lazy,
+                    "pair_idx": i,
+                    "var_x": var_x,
+                    "var_y": var_y,
+                    "level_hpa": level_hpa,
+                    "x_has_level": x_has_level,
+                    "y_has_level": y_has_level,
+                }
+            )
+
+    if not range_jobs:
+        if skipped_pairs:
+            unique_skips = sorted(set(skipped_pairs))
+            c.warn("[multivariate] Skipped pairs:\n  • " + "\n  • ".join(unique_skips))
+        return
+
+    # Compute ranges in batch
+    compute_jobs(
+        range_jobs,
+        key_map={
+            "min_x": "min_x_res",
+            "max_x": "max_x_res",
+            "min_y": "min_y_res",
+            "max_y": "max_y_res",
+        },
+        desc="Computing ranges",
+    )
+
+    # 2. Second pass: Create histogram lazy objects using computed ranges
+    hist_jobs = []
+
+    for job in range_jobs:
+        var_x = job["var_x"]
+        var_y = job["var_y"]
+        level_hpa = job["level_hpa"]
+        x_has_level = bool(job.get("x_has_level", False))
+        y_has_level = bool(job.get("y_has_level", False))
+
+        try:
+            min_x = float(job["min_x_res"])
+            max_x = float(job["max_x_res"])
+            min_y = float(job["min_y_res"])
+            max_y = float(job["max_y_res"])
+        except Exception:
+            skipped_pairs.append(f"{var_x} vs {var_y} (computation failed)")
+            continue
+
+        if np.isnan(min_x) or np.isnan(max_x) or np.isnan(min_y) or np.isnan(max_y):
+            skipped_pairs.append(f"{var_x} vs {var_y} (all NaNs)")
+            continue
+
+        range_x = [min_x, max_x]
+        range_y = [min_y, max_y]
+
+        # Replace NaNs with out-of-range value to filter them during histogram2d
+        fill_x = min_x - 1.0
+        fill_y = min_y - 1.0
+
+        # Re-access data (dask arrays)
+        pred_x = ds_prediction[var_x].sel(level=level_hpa) if x_has_level else ds_prediction[var_x]
+        pred_y = ds_prediction[var_y].sel(level=level_hpa) if y_has_level else ds_prediction[var_y]
+        da_x = pred_x.data.flatten()
+        da_y = pred_y.data.flatten()
+
+        da_x = da.where(da.isnan(da_x), fill_x, da_x)
+        da_y = da.where(da.isnan(da_y), fill_y, da_y)
+
+        # Calculate edges manually to avoid dask array edges which cannot be passed to bins=
+        xedges = np.linspace(min_x, max_x, bins + 1)
+        yedges = np.linspace(min_y, max_y, bins + 1)
+
+        h_pred_lazy, _, _ = da.histogram2d(
+            da_x, da_y, bins=[xedges, yedges], range=[range_x, range_y]
+        )
+
+        # Target data
+        if ds_target is not None:
+            targ_x = (
+                ds_target[var_x].sel(level=level_hpa)
+                if "level" in ds_target[var_x].dims and level_hpa is not None
+                else ds_target[var_x]
+            )
+            targ_y = (
+                ds_target[var_y].sel(level=level_hpa)
+                if "level" in ds_target[var_y].dims and level_hpa is not None
+                else ds_target[var_y]
+            )
+            da_x_t = targ_x.data.flatten()
+            da_y_t = targ_y.data.flatten()
+
+            da_x_t = da.where(da.isnan(da_x_t), fill_x, da_x_t)
+            da_y_t = da.where(da.isnan(da_y_t), fill_y, da_y_t)
+
+            h_target_lazy, _, _ = da.histogram2d(
+                da_x_t, da_y_t, bins=[xedges, yedges], range=[range_x, range_y]
+            )
+        else:
+            # Should not happen given checks above, but for safety
+            h_target_lazy = None
+
+        hist_jobs.append(
+            {
+                "h_pred": h_pred_lazy,
+                "h_target": h_target_lazy,
+                "xedges": xedges,
+                "yedges": yedges,
+                "var_x": var_x,
+                "var_y": var_y,
+                "level_hpa": level_hpa,
+                "range_x": range_x,
+                "range_y": range_y,
+            }
+        )
+
+    # Compute histograms in batch
+    compute_jobs(
+        hist_jobs,
+        key_map={
+            "h_pred": "hist_pred",
+            "h_target": "hist_target",
+        },
+        desc="Computing histograms",
+    )
+
+    # 3. Plotting
+    for job in hist_jobs:
+        if "hist_pred" not in job or "hist_target" not in job:
+            continue
+
+        hist_pred = job["hist_pred"]
+        hist_target = job["hist_target"]
+        xedges = job["xedges"]
+        yedges = job["yedges"]
+        var_x = job["var_x"]
+        var_y = job["var_y"]
+        level_hpa = job.get("level_hpa")
+        level_suffix = _format_level_suffix(level_hpa)
+
+        # Save and Plot
+        suffix = f"_{ensemble_token}" if ensemble_token else ""
+        out_file = (
+            out_root / "multivariate" / f"bivariate_hist_{var_x}_{var_y}{level_suffix}{suffix}.npz"
+        )
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+
+        np.savez(
+            out_file,
+            hist=hist_pred,
+            bins_x=xedges,
+            bins_y=yedges,
+            hist_target=hist_target,
+            var_x=var_x,
+            var_y=var_y,
+            level_hpa=np.nan if level_hpa is None else float(level_hpa),
+        )
+
+        # Generate plot immediately
+        fig, ax = plt.subplots(figsize=(8, 8), dpi=150)
+
+        # Suppress log scale warnings for zero values
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="Log scale: values of z <= 0 have been masked"
+            )
+            label_da_x = (
+                ds_prediction[var_x].sel(level=level_hpa)
+                if ("level" in ds_prediction[var_x].dims and level_hpa is not None)
+                else ds_prediction[var_x]
+            )
+            label_da_y = (
+                ds_prediction[var_y].sel(level=level_hpa)
+                if ("level" in ds_prediction[var_y].dims and level_hpa is not None)
+                else ds_prediction[var_y]
+            )
+            plot_bivariate_histogram(
+                hist_1=hist_pred,
+                hist_2=hist_target,
+                bins_x=xedges,
+                bins_y=yedges,
+                label_1="Model Prediction",
+                label_2="Ground Truth",
+                var_x=var_x,
+                var_y=var_y,
+                level_hpa=level_hpa,
+                ax=ax,
+                xlabel=_get_label(label_da_x, var_x),
+                ylabel=_get_label(label_da_y, var_y),
+            )
+
+        plot_out = (
+            out_root / "multivariate" / f"bivariate_{var_x}_{var_y}{level_suffix}{suffix}.png"
+        )
+        fig.savefig(plot_out, bbox_inches="tight")
+        plt.close(fig)
+
+        c.info(f"[multivariate] Saved bivariate plot: {plot_out.name}")
+        if level_hpa is None:
+            plotted_pairs.append(f"{var_x} vs {var_y}")
+        else:
+            plotted_pairs.append(f"{var_x} vs {var_y} @ {level_hpa:g} hPa")
+
+        # ── Per-lead-time grid ────────────────────────────────────────────────
+        # When the prediction dataset has multiple lead times we additionally
+        # produce one figure per level (for 3-D variables) that arranges a
+        # bivariate-histogram panel for each lead time in a grid.  The same
+        # bin edges computed above are reused so all panels are comparable.
+        if "lead_time" in ds_prediction[var_x].dims and ds_prediction.sizes.get("lead_time", 1) > 1:
+            _plot_bivariate_per_lead_grid(
+                ds_prediction=ds_prediction,
+                ds_target=ds_target,
+                var_x=var_x,
+                var_y=var_y,
+                xedges=xedges,
+                yedges=yedges,
+                out_root=out_root,
+                ensemble_token=ensemble_token,
+                level_hpa=level_hpa,
+            )
+
+    # Summary output
+    if plotted_pairs:
+        c.info(f"[multivariate] Plotted {len(plotted_pairs)} pairs: {', '.join(plotted_pairs)}")
+
+    if skipped_pairs:
+        unique_skips = sorted(set(skipped_pairs))
+        c.warn("[multivariate] Skipped pairs:\n  • " + "\n  • ".join(unique_skips))
+
+
+def plot_bivariate_histogram(
+    hist_1: np.ndarray,
+    hist_2: np.ndarray,
+    bins_x: np.ndarray,
+    bins_y: np.ndarray,
+    label_1: str,
+    label_2: str,
+    var_x: str,
+    var_y: str,
+    level_hpa: float | None = None,
+    ax: plt.Axes | None = None,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
+    xlim: tuple[float, float] | None = None,
+    ylim: tuple[float, float] | None = None,
+) -> plt.Axes:
+    """Plot bivariate histograms for two models/datasets.
+
+    Model 1 (prediction) is plotted with greyscale contour lines.
+    Model 2 (reference/ground truth) is plotted with filled color contours.
+
+    Args:
+        hist_1: 2D histogram counts for model 1 (prediction). Shape (nx, ny).
+        hist_2: 2D histogram counts for model 2 (reference). Shape (nx, ny).
+        bins_x: Bin edges for x variable.
+        bins_y: Bin edges for y variable.
+        label_1: Label for model 1 (contours).
+        label_2: Label for model 2 (filled).
+        var_x: Name of x variable.
+        var_y: Name of y variable.
+        ax: Axes to plot on. If None, creates new figure.
+        xlabel: Label for x-axis. If None, uses var_x.
+        ylabel: Label for y-axis. If None, uses var_y.
+        xlim: Optional explicit x-axis limits. When provided with ``ylim``,
+            these limits are applied before physical overlays are drawn.
+        ylim: Optional explicit y-axis limits. When provided with ``xlim``,
+            these limits are applied before physical overlays are drawn.
+
+    Returns:
+        The axes with the plot.
+    """
+    if ax is None:
+        _, ax = plt.subplots(figsize=(8, 8))
+
+    # For geopotential-height (or its gradient) vs wind-speed, enforce a physically
+    # intuitive view: x-axis = wind speed / gradient, y-axis = geopotential height.
+    if _is_geopotential_height_gradient(var_x) and _is_wind_speed(var_y):
+        # Keep gradient on x, wind speed on y — natural geostrophic axes.
+        pass
+    elif _is_geopotential_height_gradient(var_y) and _is_wind_speed(var_x):
+        # Swap so gradient is on x and wind speed is on y.
+        hist_1 = np.asarray(hist_1).T
+        hist_2 = np.asarray(hist_2).T
+        bins_x, bins_y = bins_y, bins_x
+        var_x, var_y = var_y, var_x
+        xlabel, ylabel = ylabel, xlabel
+        if xlim is not None and ylim is not None:
+            xlim, ylim = ylim, xlim
+    elif _is_geopotential_height(var_x) and _is_wind_speed(var_y):
+        hist_1 = np.asarray(hist_1).T
+        hist_2 = np.asarray(hist_2).T
+        bins_x, bins_y = bins_y, bins_x
+        var_x, var_y = var_y, var_x
+        xlabel, ylabel = ylabel, xlabel
+        if xlim is not None and ylim is not None:
+            xlim, ylim = ylim, xlim
+
+    # Calculate centers
+    x_centers = (bins_x[:-1] + bins_x[1:]) / 2
+    y_centers = (bins_y[:-1] + bins_y[1:]) / 2
+    X, Y = np.meshgrid(x_centers, y_centers, indexing="ij")
+
+    # Normalize histograms to density
+    # We divide by the sum to get probability mass, then divide by bin area to get density.
+    # Assuming uniform bins for simplicity in area calculation.
+    # Use average bin width for area calculation to support non-uniform bins.
+    dx = np.diff(bins_x).mean()
+    dy = np.diff(bins_y).mean()
+
+    if dx <= 0 or dy <= 0:
+        # Avoid division by zero or invalid bin sizes
+        if ax:
+            ax.text(
+                0.5,
+                0.5,
+                "Invalid bin sizes (dx/dy <= 0)",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
+        return ax
+
+    bin_area = dx * dy
+
+    sum_1 = hist_1.sum()
+    sum_2 = hist_2.sum()
+
+    dens_1 = hist_1 / (sum_1 * bin_area) if sum_1 > 0 else hist_1
+    dens_2 = hist_2 / (sum_2 * bin_area) if sum_2 > 0 else hist_2
+
+    # Logarithmic scale
+    # Define levels based on the filled distribution (Model 2 / ground truth)
+    valid_2 = dens_2[dens_2 > 0]
+    if len(valid_2) == 0:
+        ax.text(
+            0.5,
+            0.5,
+            "No data in reference distribution",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+        )
+        return ax
+
+    vmin = valid_2.min()
+    vmax = valid_2.max()
+
+    # Ensure vmin is positive for log scale
+    if vmin <= 0:
+        vmin = 1e-10
+
+    # Create log-spaced levels
+    # We generate N+2 levels and take the inner N to ensure the contour lines are visible
+    # and not at the absolute min/max (which are hard to see).
+    # This aligns the number of visible lines on the plot with the lines on the colorbar.
+    # Using 5 internal levels gives a clean look.
+    n_levels = 5
+    full_levels = np.logspace(np.log10(vmin), np.log10(vmax), n_levels + 2)
+    levels = full_levels[1:-1]
+
+    # Plot Model 2 (Filled, Color) - Reference / Ground Truth
+    cs2 = ax.contourf(
+        X,
+        Y,
+        dens_2,
+        levels=levels,
+        norm=LogNorm(vmin=vmin, vmax=vmax),
+        cmap="plasma",
+        extend="both",
+    )
+
+    # Plot Model 1 (Lines, Greyscale) - Prediction
+    # Use a truncated Greys colormap so low density is light grey (not white) and high is black
+    cmap_base = plt.get_cmap("Greys")
+    colors_sampled = cmap_base(np.linspace(0.3, 1.0, 256))
+    cmap_greys = mcolors.LinearSegmentedColormap.from_list("truncated_greys", colors_sampled)
+
+    cs1 = ax.contour(
+        X,
+        Y,
+        dens_1,
+        levels=levels,
+        norm=LogNorm(vmin=vmin, vmax=vmax),
+        cmap=cmap_greys,
+        linewidths=1.5,
+    )
+
+    fig = ax.get_figure()
+    if fig:
+        cbar = fig.colorbar(cs2, ax=ax, format="%.2e")
+        cbar.set_label("Density (log scale)")
+        cbar.add_lines(cs1)
+
+    ax.set_xlabel(xlabel if xlabel else var_x)
+    ax.set_ylabel(ylabel if ylabel else var_y)
+
+    if _is_geostrophic_gradient_pair(var_x, var_y):
+        ax.tick_params(axis="x", labelrotation=45)
+        for tick in ax.get_xticklabels():
+            tick.set_ha("right")
+
+    title = f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}"
+    if level_hpa is not None:
+        title += f" ({level_hpa:g} hPa)"
+    ax.set_title(title)
+
+    # Zoom out by 25%, unless explicit limits are provided by the caller.
+    if xlim is not None and ylim is not None:
+        ax.set_xlim(xlim)
+        ax.set_ylim(ylim)
+    else:
+        x_min, x_max = bins_x.min(), bins_x.max()
+        y_min, y_max = bins_y.min(), bins_y.max()
+
+        x_range = x_max - x_min
+        y_range = y_max - y_min
+
+        x_center = (x_max + x_min) / 2
+        y_center = (y_max + y_min) / 2
+
+        # Expand by 25% (factor 1.25)
+        ax.set_xlim(x_center - 0.625 * x_range, x_center + 0.625 * x_range)
+        ax.set_ylim(y_center - 0.625 * y_range, y_center + 0.625 * y_range)
+
+    # ── Physical-constraint overlays ─────────────────────────────────────────
+    final_xlim = ax.get_xlim()
+    final_ylim = ax.get_ylim()
+    constraints = _get_physical_constraints(
+        var_x,
+        var_y,
+        bins_x,
+        bins_y,
+        level_hpa=level_hpa,
+    )
+    constraint_entries = _draw_physical_constraints(
+        ax,
+        constraints,
+        x_range=(final_xlim[0], final_xlim[1]),
+        y_range=(final_ylim[0], final_ylim[1]),
+    )
+    # Re-apply limits after fill operations (fill_between can expand them)
+    ax.set_xlim(final_xlim)
+    ax.set_ylim(final_ylim)
+
+    # ── Legend ───────────────────────────────────────────────────────────────
+    # Use 3 representative colors for the filled contours (low, mid, high)
+    cmap = plt.get_cmap("plasma")
+    patch1 = mpatches.Patch(color=cmap(0.2))
+    patch2 = mpatches.Patch(color=cmap(0.5))
+    patch3 = mpatches.Patch(color=cmap(0.8))
+
+    handles = [
+        (patch1, patch2, patch3),
+        Line2D([0], [0], color="grey", lw=1.5),
+    ]
+    labels = [label_2, label_1]
+
+    # Append physical-constraint artists
+    for artist, lbl in constraint_entries:
+        handles.append(artist)
+        labels.append(lbl)
+
+    ax.legend(
+        handles=handles,
+        labels=labels,
+        loc="upper right",
+        handler_map={tuple: HandlerTuple(ndivide=None, pad=0)},
+        fontsize="small",
+        framealpha=0.85,
+    )
+
+    return ax

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -43,8 +43,12 @@ def _is_geostrophic_gradient_pair(var_x: str, var_y: str) -> bool:
 def _format_level_suffix(level_hpa: float | None) -> str:
     if level_hpa is None:
         return ""
-    if float(level_hpa).is_integer():
-        return f"_level{int(level_hpa)}"
+    # Round to nearest integer when within 0.1 hPa to handle floating-point
+    # rounding from NetCDF level coordinates (e.g. 499.9999 → 500).
+    # Using 0.1 instead of 0.5 to preserve non-integer labels like 500.6.
+    rounded = int(round(float(level_hpa)))
+    if abs(float(level_hpa) - rounded) < 0.1:
+        return f"_level{rounded}"
     return f"_level{level_hpa:g}"
 
 
@@ -108,10 +112,6 @@ def _get_physical_constraints(
         Bin-edge arrays produced by the histogram step.
     """
     constraints: list[dict] = []
-
-    # Draw physical overlays only for 500 hPa views.
-    if level_hpa is None or not np.isclose(float(level_hpa), 500.0):
-        return constraints
     lx, ly = var_x.lower(), var_y.lower()
 
     is_temp_x = "temperature" in lx
@@ -123,13 +123,18 @@ def _get_physical_constraints(
     is_ws_x = "wind_speed" in lx
     is_ws_y = "wind_speed" in ly
 
+    # Pressure for the saturation curve [Pa]: use actual level when available,
+    # fall back to surface (~1013 hPa) for 2-D variables.
+    P_Pa = float(level_hpa) * 100.0 if level_hpa is not None else 101325.0
+    level_label = f"{int(round(float(level_hpa)))} hPa" if level_hpa is not None else "surface"
+
     # ── Temperature vs Specific Humidity ────────────────────────────────────
     # Physical upper bound: q ≤ q_sat(T) — Clausius–Clapeyron.
     # Physical lower bound: q ≥ 0.
     if (is_temp_x and is_q_y) or (is_q_x and is_temp_y):
         if is_temp_x:  # temperature on x-axis, q on y-axis
             T_arr = np.linspace(bins_x[0], bins_x[-1], 400)
-            q_sat = _q_sat_at_pressure(T_arr, P_Pa=50000.0)
+            q_sat = _q_sat_at_pressure(T_arr, P_Pa=P_Pa)
             constraints.append(
                 {
                     "type": "curve",
@@ -141,7 +146,7 @@ def _get_physical_constraints(
                     "color": "#d62728",
                     "lw": 2.0,
                     "ls": "--",
-                    "label": r"$q_\mathrm{sat}(T)$ — Bolton (1980), 500 hPa",
+                    "label": rf"$q_\mathrm{{sat}}(T)$ — Bolton (1980), {level_label}",
                     "fill_alpha": 0.13,
                     "fill_color": "#d62728",
                     "fill_hatch": "///",
@@ -165,7 +170,7 @@ def _get_physical_constraints(
             )
         else:  # q on x-axis, temperature on y-axis
             T_arr = np.linspace(bins_y[0], bins_y[-1], 400)
-            q_sat = _q_sat_at_pressure(T_arr, P_Pa=50000.0)
+            q_sat = _q_sat_at_pressure(T_arr, P_Pa=P_Pa)
             constraints.append(
                 {
                     "type": "curve",
@@ -177,7 +182,7 @@ def _get_physical_constraints(
                     "color": "#d62728",
                     "lw": 2.0,
                     "ls": "--",
-                    "label": r"$q_\mathrm{sat}(T)$ — Bolton (1980), 500 hPa",
+                    "label": rf"$q_\mathrm{{sat}}(T)$ — Bolton (1980), {level_label}",
                     "fill_alpha": 0.13,
                     "fill_color": "#d62728",
                     "fill_hatch": "///",
@@ -503,8 +508,13 @@ def _plot_bivariate_per_lead_grid(
         return
 
     # ── Pre-compute fill sentinels (out-of-range substitutes for NaN) ────────
-    fill_x = float(xedges[0]) - 1.0
-    fill_y = float(yedges[0]) - 1.0
+    # Use one full data-range width below the minimum so the sentinel is always
+    # outside the histogram range, even when floating-point rounding shifts
+    # individual per-lead values slightly outside [xedges[0], xedges[-1]].
+    _x_span = max(float(xedges[-1]) - float(xedges[0]), 1.0)
+    _y_span = max(float(yedges[-1]) - float(yedges[0]), 1.0)
+    fill_x = float(xedges[0]) - _x_span
+    fill_y = float(yedges[0]) - _y_span
     range_x = [float(xedges[0]), float(xedges[-1])]
     range_y = [float(yedges[0]), float(yedges[-1])]
 
@@ -854,9 +864,10 @@ def calculate_and_plot_bivariate_histograms(
         range_x = [min_x, max_x]
         range_y = [min_y, max_y]
 
-        # Replace NaNs with out-of-range value to filter them during histogram2d
-        fill_x = min_x - 1.0
-        fill_y = min_y - 1.0
+        # Replace NaNs with a sentinel that is one full data-range width below the
+        # minimum — always outside the histogram range regardless of the data scale.
+        fill_x = min_x - max(max_x - min_x, 1.0)
+        fill_y = min_y - max(max_y - min_y, 1.0)
 
         # Re-access data (dask arrays)
         pred_x = ds_prediction[var_x].sel(level=level_hpa) if x_has_level else ds_prediction[var_x]

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -602,6 +602,8 @@ def _plot_bivariate_per_lead_grid(
     # ── Grid layout ───────────────────────────────────────────────────────────
     cols = min(3, n_leads)
     rows = int(np.ceil(n_leads / cols))
+    n_panels = cols * rows
+    font_scale = max(1.0, n_panels**0.4)
     # Extra height for the shared horizontal colorbar below the grid.
     fig, axs = plt.subplots(
         rows,
@@ -657,9 +659,10 @@ def _plot_bivariate_per_lead_grid(
                 show_colorbar=False,
                 show_legend=(i == 0),
                 coriolis_parameter=coriolis_parameter,
+                font_scale=font_scale,
             )
         # Show only lead-time label as subplot title (e.g. "+6h").
-        ax.set_title(lead_label, fontsize=10)
+        ax.set_title(lead_label, fontsize=int(round(10 * font_scale)))
         # Hide y-axis label and tick labels on every column except the leftmost.
         if i % cols != 0:
             ax.set_ylabel("")
@@ -684,13 +687,14 @@ def _plot_bivariate_per_lead_grid(
     )
     cbar.ax.xaxis.set_major_locator(mticker.LogLocator())
     cbar.ax.xaxis.set_major_formatter(mticker.LogFormatterMathtext())
-    cbar.set_label("Density (log scale)")
+    cbar.set_label("Density (log scale)", fontsize=int(round(11 * font_scale)))
+    cbar.ax.tick_params(labelsize=int(round(9 * font_scale)))
 
     lev_title = f" @ {level_hpa:g} hPa" if level_hpa is not None else ""
     fig.suptitle(
         f"Bivariate Histograms by Lead Time — "
         f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}{lev_title}",
-        fontsize=14,
+        fontsize=int(round(14 * font_scale)),
     )
 
     # ── Save ──────────────────────────────────────────────────────────────────
@@ -1069,6 +1073,7 @@ def plot_bivariate_histogram(
     show_colorbar: bool = True,
     show_legend: bool = True,
     coriolis_parameter: float = 1.0e-4,
+    font_scale: float = 1.0,
 ) -> plt.Axes:
     """Plot bivariate histograms for two models/datasets.
 
@@ -1211,14 +1216,21 @@ def plot_bivariate_histogram(
         linewidths=1.5,
     )
 
+    fs_label = int(round(12 * font_scale))
+    fs_tick = int(round(10 * font_scale))
+    fs_title = int(round(12 * font_scale))
+    fs_legend = int(round(9 * font_scale))
+
     fig = ax.get_figure()
     if show_colorbar and fig:
         cbar = fig.colorbar(cs2, ax=ax, format="%.2e")
-        cbar.set_label("Density (log scale)")
+        cbar.set_label("Density (log scale)", fontsize=fs_label)
+        cbar.ax.tick_params(labelsize=fs_tick)
         cbar.add_lines(cs1)
 
-    ax.set_xlabel(xlabel if xlabel else var_x)
-    ax.set_ylabel(ylabel if ylabel else var_y)
+    ax.set_xlabel(xlabel if xlabel else var_x, fontsize=fs_label)
+    ax.set_ylabel(ylabel if ylabel else var_y, fontsize=fs_label)
+    ax.tick_params(axis="both", labelsize=fs_tick)
 
     if _is_geostrophic_gradient_pair(var_x, var_y):
         ax.tick_params(axis="x", labelrotation=45)
@@ -1228,7 +1240,7 @@ def plot_bivariate_histogram(
     title = f"{format_variable_name(var_x)} vs {format_variable_name(var_y)}"
     if level_hpa is not None:
         title += f" ({level_hpa:g} hPa)"
-    ax.set_title(title)
+    ax.set_title(title, fontsize=fs_title)
 
     # Zoom out by 25%, unless explicit limits are provided by the caller.
     if xlim is not None and ylim is not None:
@@ -1308,13 +1320,23 @@ def plot_bivariate_histogram(
             legend_loc = "lower right"
         else:
             legend_loc = "best"
-        ax.legend(
-            handles=handles,
-            labels=labels,
-            loc=legend_loc,
-            handler_map={tuple: HandlerTuple(ndivide=None, pad=0)},
-            fontsize="small",
-            framealpha=0.85,
-        )
+        legend_kwargs: dict = {
+            "handles": handles,
+            "labels": labels,
+            "loc": legend_loc,
+            "handler_map": {tuple: HandlerTuple(ndivide=None, pad=0)},
+            "fontsize": fs_legend,
+            "framealpha": 0.85,
+        }
+        if is_zgrad_ws:
+            # Anchor the *lower*-right corner of the legend just above
+            # wind_speed = 0 in data coordinates.  Convert y=0 from data
+            # space → display space → axes-fraction space, then add a small
+            # padding so the legend box sits fully above the zero line.
+            _, y0_disp = ax.transData.transform((0, 0))
+            y0_axes = ax.transAxes.inverted().transform((0, y0_disp))[1]
+            legend_kwargs["bbox_to_anchor"] = (1.0, y0_axes + 0.01)
+            legend_kwargs["bbox_transform"] = ax.transAxes
+        ax.legend(**legend_kwargs)
 
     return ax

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -153,7 +153,7 @@ def _get_physical_constraints(
                     "fill_alpha": 0.13,
                     "fill_color": "#d62728",
                     "fill_hatch": "///",
-                    "fill_label": "Supersaturated (unphysical)",
+                    "fill_label": "Supersaturated",
                 }
             )
             constraints.append(
@@ -189,7 +189,7 @@ def _get_physical_constraints(
                     "fill_alpha": 0.13,
                     "fill_color": "#d62728",
                     "fill_hatch": "///",
-                    "fill_label": "Supersaturated (unphysical)",
+                    "fill_label": "Supersaturated",
                 }
             )
             constraints.append(
@@ -1077,16 +1077,16 @@ def plot_bivariate_histogram(
 ) -> plt.Axes:
     """Plot bivariate histograms for two models/datasets.
 
-    Model 1 (prediction) is plotted with greyscale contour lines.
-    Model 2 (reference/ground truth) is plotted with filled color contours.
+    Model 1 (prediction) is plotted with filled plasma color contours.
+    Model 2 (reference/ground truth) is plotted with greyscale contour lines.
 
     Args:
         hist_1: 2D histogram counts for model 1 (prediction). Shape (nx, ny).
         hist_2: 2D histogram counts for model 2 (reference). Shape (nx, ny).
         bins_x: Bin edges for x variable.
         bins_y: Bin edges for y variable.
-        label_1: Label for model 1 (contours).
-        label_2: Label for model 2 (filled).
+        label_1: Label for model 1 (filled).
+        label_2: Label for model 2 (contours).
         var_x: Name of x variable.
         var_y: Name of y variable.
         ax: Axes to plot on. If None, creates new figure.
@@ -1160,21 +1160,21 @@ def plot_bivariate_histogram(
     dens_2 = hist_2 / (sum_2 * bin_area) if sum_2 > 0 else hist_2
 
     # Logarithmic scale
-    # Define levels based on the filled distribution (Model 2 / ground truth)
-    valid_2 = dens_2[dens_2 > 0]
-    if len(valid_2) == 0:
+    # Define levels based on the filled distribution (Model 1 / prediction)
+    valid_1 = dens_1[dens_1 > 0]
+    if len(valid_1) == 0:
         ax.text(
             0.5,
             0.5,
-            "No data in reference distribution",
+            "No data in prediction distribution",
             ha="center",
             va="center",
             transform=ax.transAxes,
         )
         return ax
 
-    vmin = valid_2.min()
-    vmax = valid_2.max()
+    vmin = valid_1.min()
+    vmax = valid_1.max()
 
     # Ensure vmin is positive for log scale
     if vmin <= 0:
@@ -1189,18 +1189,18 @@ def plot_bivariate_histogram(
     full_levels = np.logspace(np.log10(vmin), np.log10(vmax), n_levels + 2)
     levels = full_levels[1:-1]
 
-    # Plot Model 2 (Filled, Color) - Reference / Ground Truth
+    # Plot Model 1 (Filled, Color) - Prediction
     cs2 = ax.contourf(
         X,
         Y,
-        dens_2,
+        dens_1,
         levels=levels,
         norm=LogNorm(vmin=vmin, vmax=vmax),
         cmap="plasma",
         extend="both",
     )
 
-    # Plot Model 1 (Lines, Greyscale) - Prediction
+    # Plot Model 2 (Lines, Greyscale) - Reference / Ground Truth
     # Use a truncated Greys colormap so low density is light grey (not white) and high is black
     cmap_base = plt.get_cmap("Greys")
     colors_sampled = cmap_base(np.linspace(0.3, 1.0, 256))
@@ -1209,7 +1209,7 @@ def plot_bivariate_histogram(
     cs1 = ax.contour(
         X,
         Y,
-        dens_1,
+        dens_2,
         levels=levels,
         norm=LogNorm(vmin=vmin, vmax=vmax),
         cmap=cmap_greys,
@@ -1297,7 +1297,7 @@ def plot_bivariate_histogram(
         (patch1, patch2, patch3),
         Line2D([0], [0], color="grey", lw=1.5),
     ]
-    labels = [label_2, label_1]
+    labels = [label_1, label_2]
 
     # Append physical-constraint artists
     for artist, lbl in constraint_entries:

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -209,7 +209,7 @@ def _get_physical_constraints(
             )
 
     # ── Geopotential Height Gradient vs Wind Speed ──────────────────────────
-    # Geostrophic balance: U_g = (g / f) * |∇Z|
+    # Geostrophic balance: U_g = (g / f) * |∇GH|
     # Plotted as a diagonal reference line through the origin.
     # Using representative mid-latitude |f| = 1e-4 s⁻¹ and g = 9.81 m s⁻².
     if (is_zgrad_x or is_zgrad_y) and (is_ws_x or is_ws_y):
@@ -218,7 +218,7 @@ def _get_physical_constraints(
         slope = g / f_abs  # (m s⁻¹) / (m m⁻¹)
 
         if is_zgrad_x and is_ws_y:
-            # x = |∇Z|  [m m⁻¹],  y = wind speed  [m s⁻¹]
+            # x = |∇GH|  [m m⁻¹],  y = wind speed  [m s⁻¹]
             x_arr = np.linspace(max(float(bins_x[0]), 0.0), float(bins_x[-1]), 400)
             y_arr = slope * x_arr
             constraints.append(
@@ -229,11 +229,11 @@ def _get_physical_constraints(
                     "color": "#ff7f0e",
                     "lw": 2.0,
                     "ls": "--",
-                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$",
+                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla \mathrm{GH}|$",
                 }
             )
         elif is_zgrad_y and is_ws_x:
-            # x = wind speed  [m s⁻¹],  y = |∇Z|  [m m⁻¹]
+            # x = wind speed  [m s⁻¹],  y = |∇GH|  [m m⁻¹]
             x_arr = np.linspace(max(float(bins_x[0]), 0.0), float(bins_x[-1]), 400)
             y_arr = x_arr / slope
             constraints.append(
@@ -244,7 +244,7 @@ def _get_physical_constraints(
                     "color": "#ff7f0e",
                     "lw": 2.0,
                     "ls": "--",
-                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$",
+                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla \mathrm{GH}|$",
                 }
             )
 

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -130,18 +130,13 @@ def _get_physical_constraints(
     is_ws_x = "wind_speed" in lx
     is_ws_y = "wind_speed" in ly
 
-    # Pressure for the saturation curve [Pa]: use actual level when available,
-    # fall back to surface (~1013 hPa) for 2-D variables.
-    P_Pa = float(level_hpa) * 100.0 if level_hpa is not None else 101325.0
-    level_label = f"{int(round(float(level_hpa)))} hPa" if level_hpa is not None else "surface"
-
     # ── Temperature vs Specific Humidity ────────────────────────────────────
-    # Physical upper bound: q ≤ q_sat(T) — Clausius–Clapeyron.
+    # Physical upper bound: q ≤ q_sat(T) — Clausius–Clapeyron at 500 hPa.
     # Physical lower bound: q ≥ 0.
     if (is_temp_x and is_q_y) or (is_q_x and is_temp_y):
         if is_temp_x:  # temperature on x-axis, q on y-axis
             T_arr = np.linspace(bins_x[0], bins_x[-1], 400)
-            q_sat = _q_sat_at_pressure(T_arr, P_Pa=P_Pa)
+            q_sat = _q_sat_at_pressure(T_arr, P_Pa=50000.0)
             constraints.append(
                 {
                     "type": "curve",
@@ -153,7 +148,7 @@ def _get_physical_constraints(
                     "color": "#d62728",
                     "lw": 2.0,
                     "ls": "--",
-                    "label": rf"$q_\mathrm{{sat}}(T)$ — Bolton (1980), {level_label}",
+                    "label": r"$q_\mathrm{sat}(T)$ — Bolton (1980), 500 hPa",
                     "fill_alpha": 0.13,
                     "fill_color": "#d62728",
                     "fill_hatch": "///",
@@ -177,7 +172,7 @@ def _get_physical_constraints(
             )
         else:  # q on x-axis, temperature on y-axis
             T_arr = np.linspace(bins_y[0], bins_y[-1], 400)
-            q_sat = _q_sat_at_pressure(T_arr, P_Pa=P_Pa)
+            q_sat = _q_sat_at_pressure(T_arr, P_Pa=50000.0)
             constraints.append(
                 {
                     "type": "curve",
@@ -189,7 +184,7 @@ def _get_physical_constraints(
                     "color": "#d62728",
                     "lw": 2.0,
                     "ls": "--",
-                    "label": rf"$q_\mathrm{{sat}}(T)$ — Bolton (1980), {level_label}",
+                    "label": r"$q_\mathrm{sat}(T)$ — Bolton (1980), 500 hPa",
                     "fill_alpha": 0.13,
                     "fill_color": "#d62728",
                     "fill_hatch": "///",
@@ -216,43 +211,58 @@ def _get_physical_constraints(
     # Geostrophic balance: U_g = (g / f) * |∇Z|
     # Plotted as a diagonal reference line through the origin.
     # Using representative mid-latitude |f| = 1e-4 s⁻¹ and g = 9.81 m s⁻².
+    # Guard: only draw the line when the geostrophic equilibrium x values span
+    # at least 2 % of the visible x-axis range; otherwise the line is compressed
+    # to the left edge and looks like an artefact (vertical line at x≈0).
     if (is_zgrad_x or is_zgrad_y) and (is_ws_x or is_ws_y):
         g = 9.81
         f_abs = 1.0e-4  # mid-latitude Coriolis parameter, s⁻¹
         slope = g / f_abs  # ≈ 98 100  (m s⁻¹) / (m m⁻¹)
 
+        x_range_data = max(float(bins_x[-1]) - float(bins_x[0]), 1e-12)
+        y_range_data = max(float(bins_y[-1]) - float(bins_y[0]), 1e-12)
+
         if is_zgrad_x and is_ws_y:
             # x = |∇Z|  [m m⁻¹],  y = wind speed  [m s⁻¹]
-            x_arr = np.linspace(max(bins_x[0], 0.0), bins_x[-1], 400)
-            y_arr = slope * x_arr
-            constraints.append(
-                {
-                    "type": "curve",
-                    "value_x": x_arr,
-                    "value_y": y_arr,
-                    "color": "#ff7f0e",
-                    "lw": 2.0,
-                    "ls": "--",
-                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$, "
-                    r"$f=10^{-4}\,\mathrm{s}^{-1}$",
-                }
-            )
+            # x where the geostrophic line reaches the top of the visible y range
+            x_at_ymax = float(bins_y[-1]) / slope
+            if x_at_ymax > 0.02 * x_range_data:
+                x_end = min(float(bins_x[-1]), x_at_ymax * 1.05)
+                x_arr = np.linspace(max(float(bins_x[0]), 0.0), x_end, 400)
+                y_arr = slope * x_arr
+                constraints.append(
+                    {
+                        "type": "curve",
+                        "value_x": x_arr,
+                        "value_y": y_arr,
+                        "color": "#ff7f0e",
+                        "lw": 2.0,
+                        "ls": "--",
+                        "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$, "
+                        r"$f=10^{-4}\,\mathrm{s}^{-1}$",
+                    }
+                )
         elif is_zgrad_y and is_ws_x:
             # x = wind speed  [m s⁻¹],  y = |∇Z|  [m m⁻¹]
-            x_arr = np.linspace(max(bins_x[0], 0.0), bins_x[-1], 400)
-            y_arr = x_arr / slope
-            constraints.append(
-                {
-                    "type": "curve",
-                    "value_x": x_arr,
-                    "value_y": y_arr,
-                    "color": "#ff7f0e",
-                    "lw": 2.0,
-                    "ls": "--",
-                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$, "
-                    r"$f=10^{-4}\,\mathrm{s}^{-1}$",
-                }
-            )
+            y_at_xmax = float(bins_x[-1]) / slope
+            if y_at_xmax > 0.02 * y_range_data:
+                y_end = min(float(bins_y[-1]), y_at_xmax * 1.05)
+                x_arr = np.linspace(max(float(bins_x[0]), 0.0), float(bins_x[-1]), 400)
+                y_arr = x_arr / slope
+                mask = y_arr <= y_end
+                x_arr, y_arr = x_arr[mask], y_arr[mask]
+                constraints.append(
+                    {
+                        "type": "curve",
+                        "value_x": x_arr,
+                        "value_y": y_arr,
+                        "color": "#ff7f0e",
+                        "lw": 2.0,
+                        "ls": "--",
+                        "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$, "
+                        r"$f=10^{-4}\,\mathrm{s}^{-1}$",
+                    }
+                )
 
         # Wind speed ≥ 0 hard bound
         if is_ws_y:
@@ -662,8 +672,6 @@ def _plot_bivariate_per_lead_grid(
                 show_colorbar=False,
                 show_legend=(i == 0),
             )
-        # Force square subplot regardless of data unit scales.
-        ax.set_box_aspect(1)
         # Show only lead-time label as subplot title (e.g. "+6h").
         ax.set_title(lead_label, fontsize=10)
         last_i = i
@@ -681,8 +689,8 @@ def _plot_bivariate_per_lead_grid(
         orientation="horizontal",
         location="bottom",
         pad=0.04,
-        fraction=0.04,
-        shrink=1.6,
+        fraction=0.08,
+        shrink=1.0,
     )
     cbar.ax.xaxis.set_major_locator(mticker.LogLocator())
     cbar.ax.xaxis.set_major_formatter(mticker.LogFormatterMathtext())
@@ -959,7 +967,7 @@ def calculate_and_plot_bivariate_histograms(
         # Save and Plot
         suffix = f"_{ensemble_token}" if ensemble_token else ""
         out_file = (
-            out_root / "multivariate" / f"bivariate_hist_{var_x}_{var_y}{level_suffix}{suffix}.npz"
+            out_root / "multivariate" / f"bivariate_{var_x}_{var_y}{level_suffix}{suffix}.npz"
         )
         out_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -1286,10 +1294,25 @@ def plot_bivariate_histogram(
         labels.append(lbl)
 
     if show_legend:
+        # Pin legend to a fixed corner for pairs with known data-cloud position;
+        # for all other pairs let matplotlib choose the least-obstructed corner.
+        lx_leg, ly_leg = var_x.lower(), var_y.lower()
+        is_temp_q = ("temperature" in lx_leg or "temperature" in ly_leg) and (
+            "specific_humidity" in lx_leg or "specific_humidity" in ly_leg
+        )
+        is_zgrad_ws = (
+            "geopotential_height_gradient" in lx_leg or "geopotential_height_gradient" in ly_leg
+        ) and ("wind_speed" in lx_leg or "wind_speed" in ly_leg)
+        if is_temp_q:
+            legend_loc = "upper left"
+        elif is_zgrad_ws:
+            legend_loc = "lower right"
+        else:
+            legend_loc = "best"
         ax.legend(
             handles=handles,
             labels=labels,
-            loc="upper right",
+            loc=legend_loc,
             handler_map={tuple: HandlerTuple(ndivide=None, pad=0)},
             fontsize="small",
             framealpha=0.85,

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -49,7 +49,7 @@ def _format_level_suffix(level_hpa: float | None) -> str:
 def _get_label(da: xr.DataArray, var_name: str) -> str:
     """Get a formatted label with unit for a variable from DataArray attributes."""
     name = format_variable_name(var_name)
-    unit = get_variable_units(da, var_name)
+    unit = get_variable_units(da, var_name, latex=True)
     if unit:
         return f"{name} [{unit}]"
     return name

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -93,6 +93,7 @@ def _get_physical_constraints(
     bins_x: np.ndarray,
     bins_y: np.ndarray,
     level_hpa: float | None = None,
+    coriolis_parameter: float = 1.0e-4,
 ) -> list[dict]:
     """Return a list of physical-constraint specs for the given variable pair.
 
@@ -148,7 +149,7 @@ def _get_physical_constraints(
                     "color": "#d62728",
                     "lw": 2.0,
                     "ls": "--",
-                    "label": r"$q_\mathrm{sat}(T)$ — Bolton (1980), 500 hPa",
+                    "label": r"$q_\mathrm{sat}(T)$ (Bolton)",
                     "fill_alpha": 0.13,
                     "fill_color": "#d62728",
                     "fill_hatch": "///",
@@ -184,7 +185,7 @@ def _get_physical_constraints(
                     "color": "#d62728",
                     "lw": 2.0,
                     "ls": "--",
-                    "label": r"$q_\mathrm{sat}(T)$ — Bolton (1980), 500 hPa",
+                    "label": r"$q_\mathrm{sat}(T)$ (Bolton)",
                     "fill_alpha": 0.13,
                     "fill_color": "#d62728",
                     "fill_hatch": "///",
@@ -211,58 +212,41 @@ def _get_physical_constraints(
     # Geostrophic balance: U_g = (g / f) * |∇Z|
     # Plotted as a diagonal reference line through the origin.
     # Using representative mid-latitude |f| = 1e-4 s⁻¹ and g = 9.81 m s⁻².
-    # Guard: only draw the line when the geostrophic equilibrium x values span
-    # at least 2 % of the visible x-axis range; otherwise the line is compressed
-    # to the left edge and looks like an artefact (vertical line at x≈0).
     if (is_zgrad_x or is_zgrad_y) and (is_ws_x or is_ws_y):
         g = 9.81
-        f_abs = 1.0e-4  # mid-latitude Coriolis parameter, s⁻¹
-        slope = g / f_abs  # ≈ 98 100  (m s⁻¹) / (m m⁻¹)
-
-        x_range_data = max(float(bins_x[-1]) - float(bins_x[0]), 1e-12)
-        y_range_data = max(float(bins_y[-1]) - float(bins_y[0]), 1e-12)
+        f_abs = coriolis_parameter  # Coriolis parameter, s⁻¹
+        slope = g / f_abs  # (m s⁻¹) / (m m⁻¹)
 
         if is_zgrad_x and is_ws_y:
             # x = |∇Z|  [m m⁻¹],  y = wind speed  [m s⁻¹]
-            # x where the geostrophic line reaches the top of the visible y range
-            x_at_ymax = float(bins_y[-1]) / slope
-            if x_at_ymax > 0.02 * x_range_data:
-                x_end = min(float(bins_x[-1]), x_at_ymax * 1.05)
-                x_arr = np.linspace(max(float(bins_x[0]), 0.0), x_end, 400)
-                y_arr = slope * x_arr
-                constraints.append(
-                    {
-                        "type": "curve",
-                        "value_x": x_arr,
-                        "value_y": y_arr,
-                        "color": "#ff7f0e",
-                        "lw": 2.0,
-                        "ls": "--",
-                        "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$, "
-                        r"$f=10^{-4}\,\mathrm{s}^{-1}$",
-                    }
-                )
+            x_arr = np.linspace(max(float(bins_x[0]), 0.0), float(bins_x[-1]), 400)
+            y_arr = slope * x_arr
+            constraints.append(
+                {
+                    "type": "curve",
+                    "value_x": x_arr,
+                    "value_y": y_arr,
+                    "color": "#ff7f0e",
+                    "lw": 2.0,
+                    "ls": "--",
+                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$",
+                }
+            )
         elif is_zgrad_y and is_ws_x:
             # x = wind speed  [m s⁻¹],  y = |∇Z|  [m m⁻¹]
-            y_at_xmax = float(bins_x[-1]) / slope
-            if y_at_xmax > 0.02 * y_range_data:
-                y_end = min(float(bins_y[-1]), y_at_xmax * 1.05)
-                x_arr = np.linspace(max(float(bins_x[0]), 0.0), float(bins_x[-1]), 400)
-                y_arr = x_arr / slope
-                mask = y_arr <= y_end
-                x_arr, y_arr = x_arr[mask], y_arr[mask]
-                constraints.append(
-                    {
-                        "type": "curve",
-                        "value_x": x_arr,
-                        "value_y": y_arr,
-                        "color": "#ff7f0e",
-                        "lw": 2.0,
-                        "ls": "--",
-                        "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$, "
-                        r"$f=10^{-4}\,\mathrm{s}^{-1}$",
-                    }
-                )
+            x_arr = np.linspace(max(float(bins_x[0]), 0.0), float(bins_x[-1]), 400)
+            y_arr = x_arr / slope
+            constraints.append(
+                {
+                    "type": "curve",
+                    "value_x": x_arr,
+                    "value_y": y_arr,
+                    "color": "#ff7f0e",
+                    "lw": 2.0,
+                    "ls": "--",
+                    "label": r"Geostrophic: $U_g = (g/f)\,|\nabla Z|$",
+                }
+            )
 
         # Wind speed ≥ 0 hard bound
         if is_ws_y:
@@ -475,6 +459,7 @@ def _plot_bivariate_per_lead_grid(
     out_root: Path,
     ensemble_token: str | None = None,
     level_hpa: float | None = None,
+    coriolis_parameter: float = 1.0e-4,
 ) -> None:
     """Generate a per-lead-time grid of bivariate histograms for one variable pair.
 
@@ -671,9 +656,14 @@ def _plot_bivariate_per_lead_grid(
                 ylabel=_get_label(ds_prediction[var_y], var_y),
                 show_colorbar=False,
                 show_legend=(i == 0),
+                coriolis_parameter=coriolis_parameter,
             )
         # Show only lead-time label as subplot title (e.g. "+6h").
         ax.set_title(lead_label, fontsize=10)
+        # Hide y-axis label and tick labels on every column except the leftmost.
+        if i % cols != 0:
+            ax.set_ylabel("")
+            ax.tick_params(axis="y", labelleft=False)
         last_i = i
 
     # ── Hide any surplus subplots beyond n_leads ──────────────────────────────
@@ -721,6 +711,7 @@ def calculate_and_plot_bivariate_histograms(
     out_root: Path,
     bins: int = 100,
     ensemble_token: str | None = None,
+    coriolis_parameter: float = 1.0e-4,
 ) -> None:
     """Calculate and save bivariate histograms for specified pairs.
 
@@ -735,6 +726,9 @@ def calculate_and_plot_bivariate_histograms(
         bins: Number of histogram bins along each axis.
         ensemble_token: Optional token appended to output filenames
             (e.g. ``ensmean``, ``ens0``).
+        coriolis_parameter: Coriolis parameter f [s⁻¹] used for the
+            geostrophic reference line overlay. Default 1e-4 s⁻¹ (generic
+            mid-latitude); set to e.g. 1.13e-4 for central Europe (~50 °N).
     """
     plotted_pairs = []
     skipped_pairs = []
@@ -980,6 +974,7 @@ def calculate_and_plot_bivariate_histograms(
             var_x=var_x,
             var_y=var_y,
             level_hpa=np.nan if level_hpa is None else float(level_hpa),
+            coriolis_parameter=float(coriolis_parameter),
         )
 
         # Generate plot immediately
@@ -1013,6 +1008,7 @@ def calculate_and_plot_bivariate_histograms(
                 ax=ax,
                 xlabel=_get_label(label_da_x, var_x),
                 ylabel=_get_label(label_da_y, var_y),
+                coriolis_parameter=coriolis_parameter,
             )
 
         plot_out = (
@@ -1043,6 +1039,7 @@ def calculate_and_plot_bivariate_histograms(
                 out_root=out_root,
                 ensemble_token=ensemble_token,
                 level_hpa=level_hpa,
+                coriolis_parameter=coriolis_parameter,
             )
 
     # Summary output
@@ -1071,6 +1068,7 @@ def plot_bivariate_histogram(
     ylim: tuple[float, float] | None = None,
     show_colorbar: bool = True,
     show_legend: bool = True,
+    coriolis_parameter: float = 1.0e-4,
 ) -> plt.Axes:
     """Plot bivariate histograms for two models/datasets.
 
@@ -1264,6 +1262,7 @@ def plot_bivariate_histogram(
         axis_bins_x,
         axis_bins_y,
         level_hpa=level_hpa,
+        coriolis_parameter=coriolis_parameter,
     )
     constraint_entries = _draw_physical_constraints(
         ax,

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -7,8 +7,10 @@ import dask.array as da
 import matplotlib.colors as mcolors
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
 import numpy as np
 import xarray as xr
+from matplotlib.cm import ScalarMappable
 from matplotlib.colors import LogNorm
 from matplotlib.legend_handler import HandlerTuple
 from matplotlib.lines import Line2D
@@ -567,6 +569,24 @@ def _plot_bivariate_per_lead_grid(
         desc=f"Computing bivariate histograms by lead: {var_x} vs {var_y}",
     )
 
+    # ── Compute global norm across all lead times for a consistent shared colorbar ──
+    all_vals = []
+    for job in hist_jobs:
+        h = job.get("hist_target") if job.get("hist_target") is not None else job.get("hist_pred")
+        if h is not None:
+            pos = h[h > 0]
+            if pos.size:
+                all_vals.append(pos)
+    if all_vals:
+        combined = np.concatenate(all_vals)
+        global_vmin = float(combined.min())
+        global_vmax = float(combined.max())
+    else:
+        global_vmin, global_vmax = 1e-10, 1.0
+    if global_vmin <= 0:
+        global_vmin = 1e-10
+    global_norm = LogNorm(vmin=global_vmin, vmax=global_vmax)
+
     # ── Grid layout ───────────────────────────────────────────────────────────
     cols = min(3, n_leads)
     rows = int(np.ceil(n_leads / cols))
@@ -621,6 +641,7 @@ def _plot_bivariate_per_lead_grid(
                 ax=ax,
                 xlabel=_get_label(ds_prediction[var_x], var_x),
                 ylabel=_get_label(ds_prediction[var_y], var_y),
+                show_colorbar=False,
             )
         # Replace the per-subplot title set inside plot_bivariate_histogram with
         # one that also carries the lead-time label.
@@ -633,6 +654,22 @@ def _plot_bivariate_per_lead_grid(
     # ── Hide any surplus subplots beyond n_leads ──────────────────────────────
     for j in range(last_i + 1, len(axs_flat)):
         axs_flat[j].axis("off")
+
+    # ── Shared horizontal colorbar at the bottom ──────────────────────────────
+    sm = ScalarMappable(cmap="plasma", norm=global_norm)
+    sm.set_array([])
+    cbar = fig.colorbar(
+        sm,
+        ax=axs_flat[: last_i + 1].tolist(),
+        orientation="horizontal",
+        location="bottom",
+        pad=0.04,
+        fraction=0.04,
+        shrink=0.8,
+    )
+    cbar.ax.xaxis.set_major_locator(mticker.LogLocator())
+    cbar.ax.xaxis.set_major_formatter(mticker.LogFormatterMathtext())
+    cbar.set_label("Density (log scale)")
 
     lev_title = f" @ {level_hpa:g} hPa" if level_hpa is not None else ""
     fig.suptitle(
@@ -1006,6 +1043,7 @@ def plot_bivariate_histogram(
     ylabel: str | None = None,
     xlim: tuple[float, float] | None = None,
     ylim: tuple[float, float] | None = None,
+    show_colorbar: bool = True,
 ) -> plt.Axes:
     """Plot bivariate histograms for two models/datasets.
 
@@ -1149,7 +1187,7 @@ def plot_bivariate_histogram(
     )
 
     fig = ax.get_figure()
-    if fig:
+    if show_colorbar and fig:
         cbar = fig.colorbar(cs2, ax=ax, format="%.2e")
         cbar.set_label("Density (log scale)")
         cbar.add_lines(cs1)

--- a/src/swissclim_evaluations/plots/bivariate_histograms.py
+++ b/src/swissclim_evaluations/plots/bivariate_histograms.py
@@ -615,6 +615,14 @@ def _plot_bivariate_per_lead_grid(
     axs_flat = np.atleast_1d(np.array(axs)).flatten()
 
     last_i = 0
+    # Captured once across panels so the shared colorbar can carry the
+    # greyscale truth-density isoline marks via ``cbar.add_lines`` below.
+    # Mirrors the intercomparison module
+    # (intercomparison/modules/multivariate.py); without this the shared
+    # bottom colorbar is a bare gradient with no level cues, while every
+    # per-panel single-eval colorbar carries them
+    # (see ``cbar.add_lines(cs1)`` at the end of ``plot_bivariate_histogram``).
+    shared_target_cs = None
     for i, job in enumerate(hist_jobs):
         lt = job["lt"]
         # Format lead-time label (timedelta64 → '+Nh', otherwise string)
@@ -643,7 +651,7 @@ def _plot_bivariate_per_lead_grid(
             warnings.filterwarnings(
                 "ignore", message="Log scale: values of z <= 0 have been masked"
             )
-            plot_bivariate_histogram(
+            _result = plot_bivariate_histogram(
                 hist_1=hist_pred,
                 hist_2=hist_target,
                 bins_x=xedges,
@@ -660,7 +668,10 @@ def _plot_bivariate_per_lead_grid(
                 show_legend=(i == 0),
                 coriolis_parameter=coriolis_parameter,
                 font_scale=font_scale,
+                return_contour_sets=True,
             )
+        if shared_target_cs is None and isinstance(_result, tuple):
+            shared_target_cs = _result[2]
         # Show only lead-time label as subplot title (e.g. "+6h").
         ax.set_title(lead_label, fontsize=int(round(10 * font_scale)))
         # Hide y-axis label and tick labels on every column except the leftmost.
@@ -689,6 +700,8 @@ def _plot_bivariate_per_lead_grid(
     cbar.ax.xaxis.set_major_formatter(mticker.LogFormatterMathtext())
     cbar.set_label("Density (log scale)", fontsize=int(round(11 * font_scale)))
     cbar.ax.tick_params(labelsize=int(round(9 * font_scale)))
+    if shared_target_cs is not None:
+        cbar.add_lines(shared_target_cs)
 
     lev_title = f" @ {level_hpa:g} hPa" if level_hpa is not None else ""
     fig.suptitle(
@@ -809,15 +822,14 @@ def calculate_and_plot_bivariate_histograms(
             da_x_targ = targ_x_sel.data.flatten()
             da_y_targ = targ_y_sel.data.flatten()
 
-            # Combine prediction and target for range computation
-            da_x_combined = da.concatenate([da_x_pred, da_x_targ])
-            da_y_combined = da.concatenate([da_y_pred, da_y_targ])
-
-            # Compute min/max lazily over both prediction and target, handling NaNs
-            min_x_lazy = da.nanmin(da_x_combined)
-            max_x_lazy = da.nanmax(da_x_combined)
-            min_y_lazy = da.nanmin(da_y_combined)
-            max_y_lazy = da.nanmax(da_y_combined)
+            # Bin edges are anchored to the target (truth) range only, so axes
+            # and reference contours stay invariant across model variants
+            # (e.g. different perturbation magnitudes). Prediction values
+            # outside the truth range get binned into the edge bins.
+            min_x_lazy = da.nanmin(da_x_targ)
+            max_x_lazy = da.nanmax(da_x_targ)
+            min_y_lazy = da.nanmin(da_y_targ)
+            max_y_lazy = da.nanmax(da_y_targ)
             range_jobs.append(
                 {
                     "min_x": min_x_lazy,
@@ -1074,6 +1086,7 @@ def plot_bivariate_histogram(
     show_legend: bool = True,
     coriolis_parameter: float = 1.0e-4,
     font_scale: float = 1.0,
+    return_contour_sets: bool = False,
 ) -> plt.Axes:
     """Plot bivariate histograms for two models/datasets.
 
@@ -1096,9 +1109,14 @@ def plot_bivariate_histogram(
             these limits are applied before physical overlays are drawn.
         ylim: Optional explicit y-axis limits. When provided with ``xlim``,
             these limits are applied before physical overlays are drawn.
+        return_contour_sets: When True, return ``(ax, cs_pred, cs_target)``
+            instead of just the axes. The intercomparison driver uses this to
+            attach truth-density contour-line marks to the shared colorbar via
+            ``cbar.add_lines(cs_target)``.
 
     Returns:
-        The axes with the plot.
+        The axes with the plot, or ``(ax, cs_pred, cs_target)`` if
+        ``return_contour_sets=True``.
     """
     if ax is None:
         _, ax = plt.subplots(figsize=(8, 8))
@@ -1159,10 +1177,21 @@ def plot_bivariate_histogram(
     dens_1 = hist_1 / (sum_1 * bin_area) if sum_1 > 0 else hist_1
     dens_2 = hist_2 / (sum_2 * bin_area) if sum_2 > 0 else hist_2
 
-    # Logarithmic scale
-    # Define levels based on the filled distribution (Model 1 / prediction)
+    # Logarithmic scale.
+    # Define contour levels from the *target* density so that the truth
+    # contour lines stay invariant across model variants (the truth histogram
+    # is identical for all model panels in an intercomparison; the prediction
+    # density isn't). Fall back to the prediction density if the target is
+    # all-zero / empty.
+    valid_2 = dens_2[dens_2 > 0]
     valid_1 = dens_1[dens_1 > 0]
-    if len(valid_1) == 0:
+    if len(valid_2) > 0:
+        vmin = float(valid_2.min())
+        vmax = float(valid_2.max())
+    elif len(valid_1) > 0:
+        vmin = float(valid_1.min())
+        vmax = float(valid_1.max())
+    else:
         ax.text(
             0.5,
             0.5,
@@ -1172,9 +1201,6 @@ def plot_bivariate_histogram(
             transform=ax.transAxes,
         )
         return ax
-
-    vmin = valid_1.min()
-    vmax = valid_1.max()
 
     # Ensure vmin is positive for log scale
     if vmin <= 0:
@@ -1339,4 +1365,6 @@ def plot_bivariate_histogram(
             legend_kwargs["bbox_transform"] = ax.transAxes
         ax.legend(**legend_kwargs)
 
+    if return_contour_sets:
+        return ax, cs2, cs1
     return ax

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,9 @@ class _DummyColorbarAx:
     xaxis = _DummyXAxis()
     yaxis = _DummyXAxis()
 
+    def tick_params(self, *a, **k):
+        return None
+
 
 class _DummyColorbar:
     ax = _DummyColorbarAx()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,12 @@ def _fast_plot_algorithms(monkeypatch):
 
 
 # Existing fast plotting surface simplifications -----------------------------------------
+class _DummyLine:
+    """Minimal Line2D stand-in for tests that unpack ax.plot() results."""
+
+    pass
+
+
 class _DummyImage:
     def __init__(self):
         self.cmap = None
@@ -141,9 +147,12 @@ class _DummyAxis:
         return None
 
     def plot(self, *a, **k):
-        return None
+        return [_DummyLine()]
 
     def fill_between(self, *a, **k):
+        return None
+
+    def fill_betweenx(self, *a, **k):
         return None
 
     def loglog(self, *a, **k):
@@ -236,7 +245,22 @@ class _DummyAxis:
         return _DummyFig(self)
 
 
+class _DummyXAxis:
+    def set_major_locator(self, *a, **k):
+        return None
+
+    def set_major_formatter(self, *a, **k):
+        return None
+
+
+class _DummyColorbarAx:
+    xaxis = _DummyXAxis()
+    yaxis = _DummyXAxis()
+
+
 class _DummyColorbar:
+    ax = _DummyColorbarAx()
+
     def set_label(self, *a, **k):
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,6 +235,9 @@ class _DummyAxis:
     def get_lines(self):
         return []
 
+    def get_xticklabels(self):
+        return []
+
     def contourf(self, *a, **k):
         return _DummyImage()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,6 +208,9 @@ class _DummyAxis:
     def set_aspect(self, *a, **k):
         return None
 
+    def set_box_aspect(self, *a, **k):
+        return None
+
     def set_xticks(self, *a, **k):
         return None
 

--- a/tests/test_multivariate_outputs.py
+++ b/tests/test_multivariate_outputs.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+from swissclim_evaluations.metrics.multivariate import run as run_multivariate
+from swissclim_evaluations.plots.bivariate_histograms import (
+    _format_level_suffix,
+    calculate_and_plot_bivariate_histograms,
+)
+
+# ── Dataset helpers ───────────────────────────────────────────────────────────
+
+
+def _make_2d_pair(n_time: int = 4, n_lat: int = 8, n_lon: int = 8) -> tuple[xr.Dataset, xr.Dataset]:
+    """Two 2D surface variables (time × lat × lon)."""
+    rng = np.random.default_rng(10)
+    lat = np.linspace(45.0, 47.0, n_lat)
+    lon = np.linspace(6.0, 9.0, n_lon)
+    time = np.arange(n_time)
+    coords = {"time": time, "latitude": lat, "longitude": lon}
+
+    t = rng.uniform(270, 300, (n_time, n_lat, n_lon))
+    q = rng.uniform(0.001, 0.015, (n_time, n_lat, n_lon))
+    ds_t = xr.Dataset(
+        {
+            "temperature": (["time", "latitude", "longitude"], t),
+            "specific_humidity": (["time", "latitude", "longitude"], q),
+        },
+        coords=coords,
+    )
+    ds_p = xr.Dataset(
+        {
+            "temperature": (
+                ["time", "latitude", "longitude"],
+                t + 0.5 * rng.standard_normal(t.shape),
+            ),
+            "specific_humidity": (
+                ["time", "latitude", "longitude"],
+                q + 0.001 * rng.standard_normal(q.shape),
+            ),
+        },
+        coords=coords,
+    )
+    return ds_t, ds_p
+
+
+def _make_3d_pair(n_time: int = 3, n_lat: int = 8, n_lon: int = 8) -> tuple[xr.Dataset, xr.Dataset]:
+    """Two 3D variables (time × level × lat × lon)."""
+    rng = np.random.default_rng(11)
+    lat = np.linspace(45.0, 47.0, n_lat)
+    lon = np.linspace(6.0, 9.0, n_lon)
+    levels = np.array([500, 850])
+    time = np.arange(n_time)
+    coords = {"time": time, "latitude": lat, "longitude": lon, "level": levels}
+
+    t = rng.uniform(240, 290, (n_time, len(levels), n_lat, n_lon))
+    q = rng.uniform(0.001, 0.010, (n_time, len(levels), n_lat, n_lon))
+    ds_t = xr.Dataset(
+        {
+            "temperature": (["time", "level", "latitude", "longitude"], t),
+            "specific_humidity": (["time", "level", "latitude", "longitude"], q),
+        },
+        coords=coords,
+    )
+    ds_p = xr.Dataset(
+        {
+            "temperature": (
+                ["time", "level", "latitude", "longitude"],
+                t + 0.5 * rng.standard_normal(t.shape),
+            ),
+            "specific_humidity": (
+                ["time", "level", "latitude", "longitude"],
+                q + 0.001 * rng.standard_normal(q.shape),
+            ),
+        },
+        coords=coords,
+    )
+    return ds_t, ds_p
+
+
+def _make_lead_pair(
+    n_lead: int = 3, n_lat: int = 8, n_lon: int = 8
+) -> tuple[xr.Dataset, xr.Dataset]:
+    """Two 2D variables with a lead_time dimension."""
+    rng = np.random.default_rng(12)
+    lat = np.linspace(45.0, 47.0, n_lat)
+    lon = np.linspace(6.0, 9.0, n_lon)
+    leads = np.array([np.timedelta64(6 * (i + 1), "h") for i in range(n_lead)])
+    coords = {"lead_time": leads, "latitude": lat, "longitude": lon}
+
+    t = rng.uniform(270, 300, (n_lead, n_lat, n_lon))
+    q = rng.uniform(0.001, 0.015, (n_lead, n_lat, n_lon))
+    ds_t = xr.Dataset(
+        {
+            "temperature": (["lead_time", "latitude", "longitude"], t),
+            "specific_humidity": (["lead_time", "latitude", "longitude"], q),
+        },
+        coords=coords,
+    )
+    ds_p = xr.Dataset(
+        {
+            "temperature": (
+                ["lead_time", "latitude", "longitude"],
+                t + 0.5 * rng.standard_normal(t.shape),
+            ),
+            "specific_humidity": (
+                ["lead_time", "latitude", "longitude"],
+                q + 0.001 * rng.standard_normal(q.shape),
+            ),
+        },
+        coords=coords,
+    )
+    return ds_t, ds_p
+
+
+# ── _format_level_suffix unit tests ──────────────────────────────────────────
+
+
+def test_format_level_suffix_none():
+    assert _format_level_suffix(None) == ""
+
+
+def test_format_level_suffix_integer():
+    assert _format_level_suffix(500.0) == "_level500"
+
+
+def test_format_level_suffix_near_integer():
+    """Floating-point rounding from NetCDF must map to integer label."""
+    assert _format_level_suffix(499.9999) == "_level500"
+    assert _format_level_suffix(850.0001) == "_level850"
+
+
+def test_format_level_suffix_non_integer():
+    assert _format_level_suffix(500.6) == "_level500.6"
+
+
+# ── calculate_and_plot_bivariate_histograms unit tests ───────────────────────
+
+
+def test_npz_keys_present(tmp_path: Path):
+    """Output NPZ must contain the mandatory keys."""
+    ds_t, ds_p = _make_2d_pair()
+    calculate_and_plot_bivariate_histograms(
+        ds_p, ds_t, [["temperature", "specific_humidity"]], tmp_path, bins=20
+    )
+    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*.npz"))
+    assert npzs, "Expected at least one NPZ"
+    with np.load(npzs[0]) as f:
+        for key in ("hist", "hist_target", "bins_x", "bins_y", "var_x", "var_y"):
+            assert key in f.files, f"Missing key: {key}"
+
+
+def test_per_level_files_created(tmp_path: Path):
+    """3D pair must produce one NPZ per level."""
+    ds_t, ds_p = _make_3d_pair()
+    calculate_and_plot_bivariate_histograms(
+        ds_p, ds_t, [["temperature", "specific_humidity"]], tmp_path, bins=20
+    )
+    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*_level*.npz"))
+    assert len(npzs) == 2, f"Expected 2 level files, got {len(npzs)}"
+    level_suffixes = {f.stem.split("_level")[-1] for f in npzs}
+    assert level_suffixes == {"500", "850"}
+
+
+def test_per_lead_grid_created(tmp_path: Path):
+    """Multi-lead dataset must produce a per-lead-time grid PNG."""
+    ds_t, ds_p = _make_lead_pair(n_lead=3)
+    calculate_and_plot_bivariate_histograms(
+        ds_p, ds_t, [["temperature", "specific_humidity"]], tmp_path, bins=20
+    )
+    lead_pngs = list((tmp_path / "multivariate").glob("bivariate_by_lead_*.png"))
+    assert lead_pngs, "Expected per-lead-time grid PNG"
+
+
+def test_skip_missing_variable(tmp_path: Path):
+    """Pair with a variable absent from the prediction is skipped gracefully."""
+    ds_t, ds_p = _make_2d_pair()
+    ds_p = ds_p.drop_vars("specific_humidity")
+    calculate_and_plot_bivariate_histograms(
+        ds_p, ds_t, [["temperature", "specific_humidity"]], tmp_path, bins=20
+    )
+    # No crash; no NPZ written
+    assert not list((tmp_path / "multivariate").glob("bivariate_hist_*.npz"))
+
+
+def test_physical_constraints_any_level(tmp_path: Path):
+    """Physical overlay must fire at 850 hPa (not restricted to 500 hPa)."""
+    ds_t, ds_p = _make_3d_pair()
+    # Just ensure the function completes without error for both levels
+    calculate_and_plot_bivariate_histograms(
+        ds_p,
+        ds_t,
+        [["temperature", "specific_humidity"]],
+        tmp_path,
+        bins=20,
+    )
+    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*_level850*.npz"))
+    assert npzs, "Expected NPZ for 850 hPa"
+
+
+# ── run() integration tests ───────────────────────────────────────────────────
+
+
+def test_run_mean_mode(tmp_path: Path):
+    """Mean mode writes one NPZ per pair."""
+    ds_t, ds_p = _make_2d_pair()
+    run_multivariate(
+        ds_t,
+        ds_p,
+        tmp_path,
+        metrics_cfg={"multivariate": {"bivariate_pairs": [["temperature", "specific_humidity"]]}},
+        ensemble_mode="mean",
+    )
+    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*_ensmean.npz"))
+    assert npzs
+
+
+def test_run_no_pairs_is_noop(tmp_path: Path):
+    """Empty bivariate_pairs list must not raise and must write nothing."""
+    ds_t, ds_p = _make_2d_pair()
+    run_multivariate(
+        ds_t,
+        ds_p,
+        tmp_path,
+        metrics_cfg={"multivariate": {"bivariate_pairs": []}},
+        ensemble_mode="mean",
+    )
+    assert not (tmp_path / "multivariate").exists()
+
+
+def test_run_pooled_mode(tmp_path: Path):
+    """Pooled mode stacks ensemble and writes one NPZ."""
+    rng = np.random.default_rng(99)
+    lat = np.linspace(45.0, 47.0, 6)
+    lon = np.linspace(6.0, 9.0, 6)
+    time = np.arange(4)
+    n_ens = 2
+    coords = {"time": time, "latitude": lat, "longitude": lon, "ensemble": np.arange(n_ens)}
+    shape = (n_ens, len(time), len(lat), len(lon))
+    ds_t = xr.Dataset(
+        {
+            "temperature": (
+                ["ensemble", "time", "latitude", "longitude"],
+                rng.uniform(270, 300, shape),
+            ),
+            "specific_humidity": (
+                ["ensemble", "time", "latitude", "longitude"],
+                rng.uniform(0.001, 0.015, shape),
+            ),
+        },
+        coords=coords,
+    )
+    ds_p = ds_t + 0.1 * rng.standard_normal(1)
+
+    run_multivariate(
+        ds_t,
+        ds_p,
+        tmp_path,
+        metrics_cfg={"multivariate": {"bivariate_pairs": [["temperature", "specific_humidity"]]}},
+        ensemble_mode="pooled",
+    )
+    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*_enspooled.npz"))
+    assert npzs

--- a/tests/test_multivariate_outputs.py
+++ b/tests/test_multivariate_outputs.py
@@ -146,7 +146,7 @@ def test_npz_keys_present(tmp_path: Path):
     calculate_and_plot_bivariate_histograms(
         ds_p, ds_t, [["temperature", "specific_humidity"]], tmp_path, bins=20
     )
-    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*.npz"))
+    npzs = list((tmp_path / "multivariate").glob("bivariate_*.npz"))
     assert npzs, "Expected at least one NPZ"
     with np.load(npzs[0]) as f:
         for key in ("hist", "hist_target", "bins_x", "bins_y", "var_x", "var_y"):
@@ -159,7 +159,7 @@ def test_per_level_files_created(tmp_path: Path):
     calculate_and_plot_bivariate_histograms(
         ds_p, ds_t, [["temperature", "specific_humidity"]], tmp_path, bins=20
     )
-    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*_level*.npz"))
+    npzs = list((tmp_path / "multivariate").glob("bivariate_*_level*.npz"))
     assert len(npzs) == 2, f"Expected 2 level files, got {len(npzs)}"
     level_suffixes = {f.stem.split("_level")[-1] for f in npzs}
     assert level_suffixes == {"500", "850"}
@@ -183,7 +183,7 @@ def test_skip_missing_variable(tmp_path: Path):
         ds_p, ds_t, [["temperature", "specific_humidity"]], tmp_path, bins=20
     )
     # No crash; no NPZ written
-    assert not list((tmp_path / "multivariate").glob("bivariate_hist_*.npz"))
+    assert not list((tmp_path / "multivariate").glob("bivariate_*.npz"))
 
 
 def test_physical_constraints_any_level(tmp_path: Path):
@@ -197,7 +197,7 @@ def test_physical_constraints_any_level(tmp_path: Path):
         tmp_path,
         bins=20,
     )
-    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*_level850*.npz"))
+    npzs = list((tmp_path / "multivariate").glob("bivariate_*_level850*.npz"))
     assert npzs, "Expected NPZ for 850 hPa"
 
 
@@ -214,7 +214,7 @@ def test_run_mean_mode(tmp_path: Path):
         metrics_cfg={"multivariate": {"bivariate_pairs": [["temperature", "specific_humidity"]]}},
         ensemble_mode="mean",
     )
-    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*_ensmean.npz"))
+    npzs = list((tmp_path / "multivariate").glob("bivariate_*_ensmean.npz"))
     assert npzs
 
 
@@ -262,5 +262,5 @@ def test_run_pooled_mode(tmp_path: Path):
         metrics_cfg={"multivariate": {"bivariate_pairs": [["temperature", "specific_humidity"]]}},
         ensemble_mode="pooled",
     )
-    npzs = list((tmp_path / "multivariate").glob("bivariate_hist_*_enspooled.npz"))
+    npzs = list((tmp_path / "multivariate").glob("bivariate_*_enspooled.npz"))
     assert npzs

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -31,13 +31,12 @@ def test_multivariate_smoke(tmp_path: Path):
     targets, predictions = make_synthetic_datasets(with_ensemble=False, lat=10, lon=10)
     out_root = tmp_path / "output"
 
-    # Need to know variable names from make_synthetic_datasets
-    # Usually it creates 'var_2d' and 'var_3d'
-    vars = list(targets.data_vars)
-    if len(vars) < 2:
+    # Select a deterministic bivariate pair: sort data_vars before picking
+    var_names = sorted(targets.data_vars)
+    if len(var_names) < 2:
         return  # Skip if not enough vars
 
-    pair = [vars[0], vars[1]]
+    pair = [var_names[0], var_names[1]]
 
     run_multivariate(
         ds_target=targets,

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -47,6 +47,6 @@ def test_multivariate_smoke(tmp_path: Path):
     )
 
     multi_dir = out_root / "multivariate"
-    files = list(multi_dir.glob("bivariate_hist_*.npz"))
+    files = list(multi_dir.glob("bivariate_*.npz"))
     assert len(files) > 0
-    assert f"bivariate_hist_{pair[0]}_{pair[1]}_ensmean.npz" in [f.name for f in files]
+    assert f"bivariate_{pair[0]}_{pair[1]}_ensmean.npz" in [f.name for f in files]

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from swissclim_evaluations.metrics.multivariate import run as run_multivariate
+from swissclim_evaluations.metrics.ssim import run as run_ssim
+
+from ._smoke_data import make_synthetic_datasets
+
+
+def test_ssim_smoke(tmp_path: Path):
+    # SSIM requires at least 11x11 window (default sigma=1.5 -> win_size=11)
+    targets, predictions = make_synthetic_datasets(with_ensemble=False, lat=20, lon=20)
+    out_root = tmp_path / "output"
+
+    run_ssim(
+        ds_target=targets,
+        ds_prediction=predictions,
+        out_root=out_root,
+        metrics_cfg={"ssim": {"sigma": 1.5}},
+        ensemble_mode="mean",
+    )
+
+    ssim_dir = out_root / "ssim"
+    files = list(ssim_dir.glob("ssim_ssim_*.csv"))
+    assert len(files) > 0
+    assert "ssim_ssim_ensmean.csv" in [f.name for f in files]
+
+
+def test_multivariate_smoke(tmp_path: Path):
+    targets, predictions = make_synthetic_datasets(with_ensemble=False, lat=10, lon=10)
+    out_root = tmp_path / "output"
+
+    # Need to know variable names from make_synthetic_datasets
+    # Usually it creates 'var_2d' and 'var_3d'
+    vars = list(targets.data_vars)
+    if len(vars) < 2:
+        return  # Skip if not enough vars
+
+    pair = [vars[0], vars[1]]
+
+    run_multivariate(
+        ds_target=targets,
+        ds_prediction=predictions,
+        out_root=out_root,
+        metrics_cfg={"multivariate": {"bivariate_pairs": [pair]}},
+        ensemble_mode="mean",
+    )
+
+    multi_dir = out_root / "multivariate"
+    files = list(multi_dir.glob("bivariate_hist_*.npz"))
+    assert len(files) > 0
+    assert f"bivariate_hist_{pair[0]}_{pair[1]}_ensmean.npz" in [f.name for f in files]


### PR DESCRIPTION
## Summary

- Adds bivariate histogram evaluation as a new `multivariate` module (`metrics/multivariate.py`)
- Adds a full bivariate histogram plotting library (`plots/bivariate_histograms.py`) with physical overlays (saturation curve, geostrophic wind), shared axes, shared colorbar, and multi-lead grid plots
- Adds multivariate intercomparison (`intercomparison/modules/multivariate.py`)
- Adds LaTeX unit formatting helper (`_to_latex_units`) to `helpers.py`
- Wires multivariate into runner, intercompare dispatcher, example config, and docs

closes #54 and #97

## New files
- `src/swissclim_evaluations/metrics/multivariate.py` — computes 2D histograms for configured variable pairs
- `src/swissclim_evaluations/plots/bivariate_histograms.py` — renders density plots with physical constraint overlays
- `src/swissclim_evaluations/intercomparison/modules/multivariate.py` — loads per-model NPZ files and renders side-by-side comparison plots

## Config
```yaml
modules:
  multivariate: true

metrics:
  multivariate:
    bivariate_pairs:
      - ["10m_u_component_of_wind", "10m_v_component_of_wind"]
      - ["temperature", "specific_humidity"]
      - ["geopotential", "temperature"]
```