### PR TITLE
Fix dimension ordering

### DIFF
--- a/src/swissclim_evaluations/data.py
+++ b/src/swissclim_evaluations/data.py
@@ -341,6 +341,13 @@ def standardize_dims(
         raise ValueError(
             f"Dataset '{dataset_name}' has unsupported dims {bad_dims}. Allowed: {ALLOWED_DIMS}."
         )
+
+    # Enforce canonical dimension order so that .values always yields a predictable
+    # axis layout regardless of how the source zarr stored the data.
+    # Canonical order: init_time, lead_time, ensemble, level, latitude, longitude
+    canonical_order = [d for d in ("init_time", "lead_time", "ensemble", "level", "latitude", "longitude") if d in ds.dims]
+    ds = ds.transpose(*canonical_order)
+
     # (debug logging removed)
     return ds
 

--- a/src/swissclim_evaluations/plots/maps.py
+++ b/src/swissclim_evaluations/plots/maps.py
@@ -238,10 +238,6 @@ def run(
                 ds_prediction_var = ds_prediction_var.squeeze()
                 ds_var = unwrap_longitude_for_plot(ds_var)
                 ds_prediction_var = unwrap_longitude_for_plot(ds_prediction_var)
-                if "latitude" in ds_var.dims and "longitude" in ds_var.dims:
-                    ds_var = ds_var.transpose("latitude", "longitude")
-                if "latitude" in ds_prediction_var.dims and "longitude" in ds_prediction_var.dims:
-                    ds_prediction_var = ds_prediction_var.transpose("latitude", "longitude")
 
                 lon = ds_var.coords.get("longitude", None)
                 lat = ds_var.coords.get("latitude", None)
@@ -532,10 +528,6 @@ def run(
                         ds_p_lead = ds_p_lead.squeeze()
                         ds_t_lead = unwrap_longitude_for_plot(ds_t_lead)
                         ds_p_lead = unwrap_longitude_for_plot(ds_p_lead)
-                        if "latitude" in ds_t_lead.dims and "longitude" in ds_t_lead.dims:
-                            ds_t_lead = ds_t_lead.transpose("latitude", "longitude")
-                        if "latitude" in ds_p_lead.dims and "longitude" in ds_p_lead.dims:
-                            ds_p_lead = ds_p_lead.transpose("latitude", "longitude")
 
                         lon = ds_t_lead.coords.get("longitude", None)
                         lat = ds_t_lead.coords.get("latitude", None)


### PR DESCRIPTION
This pull request ensures that data arrays used in map plotting are consistently ordered by latitude and longitude. This helps prevent issues with plotting routines that expect a specific dimension order.