### PR TITLE
Implement per-lead maps and error maps output (for gif creation)

### DIFF
--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -167,11 +167,17 @@ plotting:
   # Base DPI for plots.
   dpi: 48
 
-  # Layout for multi-lead map plots from the maps module.
-  # 'panel' stacks all lead times as rows in a single figure (default).
-  # 'single' saves each lead time as a separate PNG file.
+  # How lead times are laid out in map plots (maps module).
+  # 'stacked'  (default): all lead times as rows in a single figure.
+  # 'per_lead': one PNG per lead time.
   # Both modes share the same colour scale across all leads.
-  maps_multi_lead_layout: panel  # panel | single
+  maps_lead_layout: stacked  # stacked | per_lead
+
+  # How pressure levels are arranged when maps_lead_layout = per_lead (maps module).
+  # 'per_level' (default): one PNG per lead per level.
+  # 'stacked': one PNG per lead with all pressure levels stacked as rows.
+  #   Per-level colour scales are fixed across lead frames for GIF-ready output.
+  maps_level_layout: per_level  # per_level | stacked
 
   # Maximum number of samples per latitude band used for KDE/Wasserstein in wd_kde.
   # Larger values improve smoothness but increase compute and memory. Typical: 50_000–200_000.
@@ -278,13 +284,20 @@ metrics:
     # If true, generate spatial error maps (PNG + NPZ) for MAE, RMSE, and Bias.
     # For 3D variables one map per pressure level is produced. Disabled by default
     # because these maps are memory-intensive (the full spatial field must be materialised).
-    spatial_maps: false
+    # Legacy key 'spatial_maps' is still accepted as a fallback.
+    error_maps: false
 
-    # Layout for multi-lead spatial metric map plots.
-    # 'panel' stacks all lead times as rows in a single figure (default).
-    # 'single' saves each lead time as a separate PNG file.
+    # How lead times are laid out in error map plots (deterministic module).
+    # 'stacked'  (default): all lead times as rows in a single figure.
+    # 'per_lead': one PNG per lead time.
     # Both modes share the same colour scale across all leads.
-    spatial_maps_layout: panel  # panel | single
+    error_maps_lead_layout: stacked  # stacked | per_lead
+
+    # How pressure levels are arranged when error_maps_lead_layout = per_lead.
+    # 'per_level' (default): one PNG per lead per level.
+    # 'stacked': one PNG per lead with all pressure levels stacked as rows.
+    #   Per-level colour scales are fixed across lead frames for GIF-ready output.
+    error_maps_level_layout: per_level  # per_level | stacked
 
     # In members mode, also emit a mean-of-members summary CSV.
     # aggregate_members_mean: true

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -167,6 +167,12 @@ plotting:
   # Base DPI for plots.
   dpi: 48
 
+  # Layout for multi-lead map plots from the maps module.
+  # 'panel' stacks all lead times as rows in a single figure (default).
+  # 'single' saves each lead time as a separate PNG file.
+  # Both modes share the same colour scale across all leads.
+  maps_multi_lead_layout: panel  # panel | single
+
   # Maximum number of samples per latitude band used for KDE/Wasserstein in wd_kde.
   # Larger values improve smoothness but increase compute and memory. Typical: 50_000–200_000.
   # Accepts:
@@ -270,10 +276,15 @@ metrics:
     report_per_level: true
 
     # If true, generate spatial error maps (PNG + NPZ) for MAE, RMSE, and Bias.
-    # For 3D variables one map per pressure level is produced; multi-lead runs
-    # show each lead time as a separate row. Disabled by default because these
-    # maps are memory-intensive (the full spatial field must be materialised).
+    # For 3D variables one map per pressure level is produced. Disabled by default
+    # because these maps are memory-intensive (the full spatial field must be materialised).
     spatial_maps: false
+
+    # Layout for multi-lead spatial metric map plots.
+    # 'panel' stacks all lead times as rows in a single figure (default).
+    # 'single' saves each lead time as a separate PNG file.
+    # Both modes share the same colour scale across all leads.
+    spatial_maps_layout: panel  # panel | single
 
     # In members mode, also emit a mean-of-members summary CSV.
     # aggregate_members_mean: true

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -85,24 +85,39 @@ When `output_mode` is `plot`, `npz`, or `both`, the deterministic module also pr
 spatial-field metric maps for every selected variable (2-D and 3-D at each pressure level).
 Only metrics present in `deterministic.include` are generated (by default all three).
 
-The layout for multi-lead runs is controlled by `metrics.deterministic.spatial_maps_layout`:
-- `panel` (default): all lead times stacked as rows in a single figure.
-- `single`: one PNG per lead time with a per-lead filename qualifier; all leads share the same colour scale.
+Two orthogonal flags control the layout:
+
+**`metrics.deterministic.error_maps_lead_layout`** — how lead times are handled:
+- `stacked` (default): all lead times stacked as rows in a single figure.
+- `per_lead`: one PNG per lead time with a per-lead filename qualifier; all leads share the same colour scale.
+
+**`metrics.deterministic.error_maps_level_layout`** — how pressure levels are arranged inside each lead frame (only meaningful when `error_maps_lead_layout = per_lead`):
+- `per_level` (default): one PNG per lead **per level** — existing behaviour, unchanged.
+- `stacked`: one PNG per lead with **all pressure levels stacked as rows**. Each level retains its own colour scale, kept fixed across lead frames, so the sequence of PNGs loops cleanly as a GIF.
 
 ```text
-# panel mode (default)
+# stacked mode (default) — 2D and 3D
 det_mae_map_2m_temperature_ensmean.png
 det_mae_map_2m_temperature_ensmean.npz
 det_rmse_map_2m_temperature_ensmean.png
-det_bias_map_2m_temperature_lead000h-072h_ensmean.png   # multi-lead panel
-det_mae_map_temperature_500_init2023010200-2023010412_ensmean.png   # 3D per-level
+det_bias_map_2m_temperature_lead000h-072h_ensmean.png          # multi-lead stacked
+det_mae_map_temperature_500_init2023010200-2023010412_ensmean.png   # 3D per-level stacked
 det_mae_map_temperature_500_init2023010200-2023010412_ensmean.npz
 
-# single mode
-det_bias_map_2m_temperature_lead000h_ensmean.png        # lead 0 h
-det_bias_map_2m_temperature_lead024h_ensmean.png        # lead 24 h
-det_bias_map_2m_temperature_lead072h_ensmean.png        # lead 72 h
+# per_lead + per_level (default for 3D) — one file per lead per level
+det_bias_map_2m_temperature_lead000h_ensmean.png               # 2D, lead 0 h
+det_bias_map_2m_temperature_lead024h_ensmean.png
+det_bias_map_temperature_500_lead000h_init2023010200-2023010412_ensmean.png  # 3D, 500 hPa, lead 0 h
+det_bias_map_temperature_500_lead024h_init2023010200-2023010412_ensmean.png
+det_bias_map_temperature_850_lead000h_init2023010200-2023010412_ensmean.png  # 3D, 850 hPa, lead 0 h
+
+# per_lead + stacked — one file per lead, all levels as rows (GIF-ready)
+det_bias_map_temperature_500_to_850_lead000h_init2023010200-2023010412_ensmean.png  # all levels, lead 0 h
+det_bias_map_temperature_500_to_850_lead024h_init2023010200-2023010412_ensmean.png  # all levels, lead 24 h
+det_bias_map_temperature_500_to_850_lead072h_init2023010200-2023010412_ensmean.png  # all levels, lead 72 h
 ```
+
+> **Note:** `error_maps_level_layout = stacked` has no effect on 2D variables or when only one pressure level is present. NPZ output is always written per level (unaffected by either layout flag).
 
 NPZ keys: `mae` (or `rmse`/`bias`) — mean spatial field, `latitude`, `longitude`,
 `variable`, `units`, and optionally `level`, `<metric>_per_lead` (3-D stack), `lead_labels`.
@@ -193,21 +208,35 @@ Outputs (standardized naming):
 
 Maps include the selected (or single) init/lead span and ensemble token. In members mode one PNG (and/or NPZ if `output_mode` includes it) per member is produced.
 
-The layout for multi-lead runs is controlled by `plotting.maps_multi_lead_layout`:
-- `panel` (default): all lead times stacked as rows in a single figure.
-- `single`: one PNG per lead time with a per-lead filename qualifier; all leads share the same colour scale.
+Two orthogonal flags control the layout:
+
+**`plotting.maps_lead_layout`** — how lead times are handled:
+- `stacked` (default): all lead times stacked as rows in a single figure.
+- `per_lead`: one PNG per lead time with a per-lead filename qualifier; all leads share the same colour scale.
+
+**`plotting.maps_level_layout`** — how pressure levels are arranged inside each lead frame (only meaningful when `maps_lead_layout = per_lead`):
+- `per_level` (default): one PNG per lead **per level** — existing behaviour, unchanged.
+- `stacked`: one PNG per lead with **all pressure levels stacked as rows**. Each level retains its own colour scale, kept fixed across lead frames, so the sequence of PNGs loops cleanly as a GIF.
 
 ```text
-# panel mode (default)
-map_10m_u_component_of_wind_init2023010200-2023010412_ens0.png      # member 0, all leads
-map_temperature_500_init2023010200-2023010412_ensmean.png           # mean reduction, all leads
-map_10m_u_component_of_wind_init2023010200-2023010412_ens3.npz      # NPZ export (output_mode=npz/both)
+# stacked mode (default)
+map_10m_u_component_of_wind_init2023010200-2023010412_ens0.png         # member 0, all leads
+map_temperature_500_init2023010200-2023010412_ensmean.png              # 3D, per-level stacked
+map_10m_u_component_of_wind_init2023010200-2023010412_ens3.npz         # NPZ export
 
-# single mode
-map_10m_u_component_of_wind_lead000h_init2023010200-2023010412_ens0.png   # lead 0 h
-map_10m_u_component_of_wind_lead024h_init2023010200-2023010412_ens0.png   # lead 24 h
-map_10m_u_component_of_wind_lead072h_init2023010200-2023010412_ens0.png   # lead 72 h
+# per_lead + per_level (default for 3D) — one file per lead per level
+map_10m_u_component_of_wind_lead000h_init2023010200-2023010412_ens0.png  # 2D, lead 0 h
+map_10m_u_component_of_wind_lead024h_init2023010200-2023010412_ens0.png
+map_temperature_500_lead000h_init2023010200-2023010412_ensmean.png       # 3D, 500 hPa, lead 0 h
+map_temperature_850_lead000h_init2023010200-2023010412_ensmean.png       # 3D, 850 hPa, lead 0 h
+
+# per_lead + stacked — one file per lead, all levels as rows (GIF-ready)
+map_temperature_500_to_850_lead000h_init2023010200-2023010412_ensmean.png  # all levels, lead 0 h
+map_temperature_500_to_850_lead024h_init2023010200-2023010412_ensmean.png  # all levels, lead 24 h
+map_temperature_500_to_850_lead072h_init2023010200-2023010412_ensmean.png  # all levels, lead 72 h
 ```
+
+> **Note:** `maps_level_layout = stacked` has no effect on 2D variables or when only one pressure level is present. NPZ output is always written per level (unaffected by either layout flag).
 
 **3D variables and multi-lead NPZ files**: For 3D atmospheric variables evaluated with more than one lead time, the NPZ files are saved **per pressure level** (one file per level) with the full lead-time stack preserved:
 

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -84,15 +84,24 @@ det_line_temperature_500_MAE_by_lead_ensmean.csv   # 3D variable with level toke
 When `output_mode` is `plot`, `npz`, or `both`, the deterministic module also produces
 spatial-field metric maps for every selected variable (2-D and 3-D at each pressure level).
 Only metrics present in `deterministic.include` are generated (by default all three).
-For multi-lead runs each lead time is shown as a separate row in the figure.
+
+The layout for multi-lead runs is controlled by `metrics.deterministic.spatial_maps_layout`:
+- `panel` (default): all lead times stacked as rows in a single figure.
+- `single`: one PNG per lead time with a per-lead filename qualifier; all leads share the same colour scale.
 
 ```text
+# panel mode (default)
 det_mae_map_2m_temperature_ensmean.png
 det_mae_map_2m_temperature_ensmean.npz
 det_rmse_map_2m_temperature_ensmean.png
-det_bias_map_2m_temperature_lead000h-072h_ensmean.png   # multi-lead
+det_bias_map_2m_temperature_lead000h-072h_ensmean.png   # multi-lead panel
 det_mae_map_temperature_500_init2023010200-2023010412_ensmean.png   # 3D per-level
 det_mae_map_temperature_500_init2023010200-2023010412_ensmean.npz
+
+# single mode
+det_bias_map_2m_temperature_lead000h_ensmean.png        # lead 0 h
+det_bias_map_2m_temperature_lead024h_ensmean.png        # lead 24 h
+det_bias_map_2m_temperature_lead072h_ensmean.png        # lead 72 h
 ```
 
 NPZ keys: `mae` (or `rmse`/`bias`) — mean spatial field, `latitude`, `longitude`,
@@ -184,10 +193,20 @@ Outputs (standardized naming):
 
 Maps include the selected (or single) init/lead span and ensemble token. In members mode one PNG (and/or NPZ if `output_mode` includes it) per member is produced.
 
+The layout for multi-lead runs is controlled by `plotting.maps_multi_lead_layout`:
+- `panel` (default): all lead times stacked as rows in a single figure.
+- `single`: one PNG per lead time with a per-lead filename qualifier; all leads share the same colour scale.
+
 ```text
-map_10m_u_component_of_wind_init2023010200-2023010412_ens0.png   # member 0
-map_temperature_500_init2023010200-2023010412_ensmean.png        # mean reduction
-map_10m_u_component_of_wind_init2023010200-2023010412_ens3.npz   # NPZ export (output_mode=npz/both)
+# panel mode (default)
+map_10m_u_component_of_wind_init2023010200-2023010412_ens0.png      # member 0, all leads
+map_temperature_500_init2023010200-2023010412_ensmean.png           # mean reduction, all leads
+map_10m_u_component_of_wind_init2023010200-2023010412_ens3.npz      # NPZ export (output_mode=npz/both)
+
+# single mode
+map_10m_u_component_of_wind_lead000h_init2023010200-2023010412_ens0.png   # lead 0 h
+map_10m_u_component_of_wind_lead024h_init2023010200-2023010412_ens0.png   # lead 24 h
+map_10m_u_component_of_wind_lead072h_init2023010200-2023010412_ens0.png   # lead 72 h
 ```
 
 **3D variables and multi-lead NPZ files**: For 3D atmospheric variables evaluated with more than one lead time, the NPZ files are saved **per pressure level** (one file per level) with the full lead-time stack preserved:

--- a/src/swissclim_evaluations/data.py
+++ b/src/swissclim_evaluations/data.py
@@ -345,7 +345,11 @@ def standardize_dims(
     # Enforce canonical dimension order so that .values always yields a predictable
     # axis layout regardless of how the source zarr stored the data.
     # Canonical order: init_time, lead_time, ensemble, level, latitude, longitude
-    canonical_order = [d for d in ("init_time", "lead_time", "ensemble", "level", "latitude", "longitude") if d in ds.dims]
+    canonical_order = [
+        d
+        for d in ("init_time", "lead_time", "ensemble", "level", "latitude", "longitude")
+        if d in ds.dims
+    ]
     ds = ds.transpose(*canonical_order)
 
     # (debug logging removed)

--- a/src/swissclim_evaluations/metrics/deterministic/orchestrator.py
+++ b/src/swissclim_evaluations/metrics/deterministic/orchestrator.py
@@ -43,6 +43,7 @@ def _generate_spatial_metric_maps(
     ens_token: str | None,
     save_fig: bool,
     save_npz: bool,
+    single_map_mode: bool = False,
 ) -> None:
     """Generate spatial-field metric maps for each variable.
 
@@ -91,6 +92,7 @@ def _generate_spatial_metric_maps(
             # ── Build list of lead-time slices ───────────────────────────
             lead_indices: list[int | None] = []
             lead_labels: list[str] = []
+            lead_vals = None
             if has_lead:
                 lead_src = tgt_sel if "lead_time" in tgt_sel.dims else pred_sel
                 n_leads = int(lead_src.sizes["lead_time"])
@@ -152,24 +154,37 @@ def _generate_spatial_metric_maps(
                 n_rows = len(lead_indices)
 
                 if save_fig:
-                    fig, axes = plt.subplots(
-                        n_rows,
-                        1,
-                        figsize=(10, 4 * n_rows),
-                        dpi=200,
-                        subplot_kw={
-                            "projection": ccrs.PlateCarree(),
-                        },
-                        constrained_layout=True,
-                    )
-                    if n_rows == 1:
-                        axes = np.array([axes])
+                    if not single_map_mode:
+                        fig, axes = plt.subplots(
+                            n_rows,
+                            1,
+                            figsize=(10, 4 * n_rows),
+                            dpi=200,
+                            subplot_kw={
+                                "projection": ccrs.PlateCarree(),
+                            },
+                            constrained_layout=True,
+                        )
+                        if n_rows == 1:
+                            axes = np.array([axes])
+                        im = None
 
-                    im = None
                     for i, (li, lead_str) in enumerate(
                         zip(lead_indices, lead_labels, strict=False)
                     ):
-                        ax = axes[i]
+                        if single_map_mode:
+                            fig, _ax = plt.subplots(
+                                1,
+                                1,
+                                figsize=(10, 4),
+                                dpi=200,
+                                subplot_kw={"projection": ccrs.PlateCarree()},
+                                constrained_layout=True,
+                            )
+                            axes = np.array([_ax])
+                            im = None
+
+                        ax = axes[0 if single_map_mode else i]
                         t = _reduce_to_spatial(tgt_sel, li)
                         p = _reduce_to_spatial(pred_sel, li)
                         t = unwrap_longitude_for_plot(t)
@@ -213,33 +228,74 @@ def _generate_spatial_metric_maps(
                             f"{lvl_label}{lead_part}"
                         )
 
-                    if im is not None:
-                        cb = fig.colorbar(
-                            im,
-                            ax=axes,
-                            orientation="horizontal",
-                            fraction=0.05,
-                            pad=0.02,
-                        )
-                        label = metric_name
-                        if units:
-                            label += f" [{units}]"
-                        with contextlib.suppress(Exception):
-                            cb.set_label(label)
+                        if single_map_mode:
+                            if im is not None:
+                                cb = fig.colorbar(
+                                    im,
+                                    ax=axes,
+                                    orientation="horizontal",
+                                    fraction=0.05,
+                                    pad=0.02,
+                                )
+                                label = metric_name
+                                if units:
+                                    label += f" [{units}]"
+                                with contextlib.suppress(Exception):
+                                    cb.set_label(label)
+                            lev_tok = (
+                                format_level_token(int(level_val))
+                                if level_val is not None
+                                else None
+                            )
+                            lead_qualifier = None
+                            if li is not None and lead_vals is not None:
+                                lt = lead_vals[li]
+                                if np.issubdtype(type(lt), np.timedelta64):
+                                    h = int(lt / np.timedelta64(1, "h"))
+                                    lead_qualifier = f"lead{h:03d}h"
+                            out_png = section_output / build_output_filename(
+                                metric=f"det_{metric_key}_map",
+                                variable=str(var),
+                                level=lev_tok,
+                                qualifier=lead_qualifier,
+                                init_time_range=_init_tup,
+                                lead_time_range=None,
+                                ensemble=ens_token,
+                                ext="png",
+                            )
+                            save_figure(fig, out_png, module="deterministic")
+                            plt.close(fig)
 
-                    lev_tok = format_level_token(int(level_val)) if level_val is not None else None
-                    out_png = section_output / build_output_filename(
-                        metric=f"det_{metric_key}_map",
-                        variable=str(var),
-                        level=lev_tok,
-                        qualifier=None,
-                        init_time_range=_init_tup,
-                        lead_time_range=lead_range,
-                        ensemble=ens_token,
-                        ext="png",
-                    )
-                    save_figure(fig, out_png, module="deterministic")
-                    plt.close(fig)
+                    if not single_map_mode:
+                        if im is not None:
+                            cb = fig.colorbar(
+                                im,
+                                ax=axes,
+                                orientation="horizontal",
+                                fraction=0.05,
+                                pad=0.02,
+                            )
+                            label = metric_name
+                            if units:
+                                label += f" [{units}]"
+                            with contextlib.suppress(Exception):
+                                cb.set_label(label)
+
+                        lev_tok = (
+                            format_level_token(int(level_val)) if level_val is not None else None
+                        )
+                        out_png = section_output / build_output_filename(
+                            metric=f"det_{metric_key}_map",
+                            variable=str(var),
+                            level=lev_tok,
+                            qualifier=None,
+                            init_time_range=_init_tup,
+                            lead_time_range=lead_range,
+                            ensemble=ens_token,
+                            ext="png",
+                        )
+                        save_figure(fig, out_png, module="deterministic")
+                        plt.close(fig)
 
                 if save_npz:
                     mean_field = np.nanmean(fields, axis=0)
@@ -293,6 +349,7 @@ def run(
     save_fig = mode in ("plot", "both")
     save_npz = mode in ("npz", "both")
     spatial_maps = bool(cfg.get("spatial_maps", False))
+    spatial_maps_single_mode = str(cfg.get("spatial_maps_layout", "panel")).lower() == "single"
     include = cfg.get("include")
     std_include = cfg.get("standardized_include")
     fss_cfg = cfg.get("fss", {})
@@ -543,6 +600,7 @@ def run(
                     ens_token=ens_token,
                     save_fig=save_fig,
                     save_npz=save_npz,
+                    single_map_mode=spatial_maps_single_mode,
                 )
             except Exception:
                 c.warn("[deterministic] Spatial metric map generation failed")

--- a/src/swissclim_evaluations/metrics/deterministic/orchestrator.py
+++ b/src/swissclim_evaluations/metrics/deterministic/orchestrator.py
@@ -44,6 +44,7 @@ def _generate_spatial_metric_maps(
     save_fig: bool,
     save_npz: bool,
     single_map_mode: bool = False,
+    level_grid_mode: bool = False,
 ) -> None:
     """Generate spatial-field metric maps for each variable.
 
@@ -222,10 +223,15 @@ def _generate_spatial_metric_maps(
                             int(level_val) if level_val is not None else None
                         )
                         lead_part = f" ({lead_str})" if lead_str else ""
+                        if single_map_mode and _init_tup is not None:
+                            s, e = _init_tup
+                            init_str = f" ({s})" if s == e else f" ({s}–{e})"
+                        else:
+                            init_str = ""
                         ax.set_title(
                             f"{metric_name} — "
                             f"{format_variable_name(str(var))}"
-                            f"{lvl_label}{lead_part}"
+                            f"{lvl_label}{lead_part}{init_str}"
                         )
 
                         if single_map_mode:
@@ -328,6 +334,178 @@ def _generate_spatial_metric_maps(
                     )
                     save_data(out_npz, module="deterministic", **npz_data)
 
+        # ── Grid mode: per-lead figures, all levels as rows ──────────────────
+        # Only active when single_map_mode + level_grid_mode + multi-level 3D data.
+        # Produces one PNG per lead; all pressure levels appear as rows with
+        # per-level colour scales that are consistent across lead frames.
+        if save_fig and has_level and len(levels) > 1 and level_grid_mode and single_map_mode:
+            _lv0 = levels[0]
+            _tgt0 = tgt_da.sel(level=_lv0)
+            _pred0 = pred_da.sel(level=_lv0)
+            _lead_src0 = _tgt0 if "lead_time" in _tgt0.dims else _pred0
+            lead_indices_g: list[int | None] = []
+            lead_labels_g: list[str] = []
+            lead_vals_g: np.ndarray | None = None
+            if has_lead:
+                lead_vals_g = _lead_src0["lead_time"].values
+                for _idx in range(int(_lead_src0.sizes["lead_time"])):
+                    lead_indices_g.append(_idx)
+                    _lt = lead_vals_g[_idx]
+                    if np.issubdtype(type(_lt), np.timedelta64):
+                        _h = int(_lt / np.timedelta64(1, "h"))
+                        lead_labels_g.append(f"+{_h}h")
+                    else:
+                        lead_labels_g.append(f"lead={_lt}")
+            else:
+                lead_indices_g = [None]
+                lead_labels_g = [""]
+            _init_tup_g: tuple[str, str] | None = (
+                (init_range, init_range) if isinstance(init_range, str) else init_range
+            )
+
+            def _reduce_grid(da: xr.DataArray, li: int | None) -> xr.DataArray:
+                d = da
+                if li is not None and "lead_time" in d.dims:
+                    d = d.isel(lead_time=li)
+                for _dim in ("init_time", "time"):
+                    if _dim in d.dims and d.sizes[_dim] > 1:
+                        d = d.mean(dim=_dim, keep_attrs=True)
+                return d.squeeze()
+
+            for metric_name in sorted(metrics_to_generate):
+                spec = SPATIAL_METRIC_SPECS[metric_name]
+                metric_key = spec["key"]
+
+                # Pre-compute fields and per-level colour limits (fixed across leads).
+                lev_data_g: dict[int, tuple[float, float, list[np.ndarray]]] = {}
+                for _lv in levels:
+                    _lv_int = int(_lv.values) if hasattr(_lv, "values") else int(_lv)
+                    _tgt_lv = tgt_da.sel(level=_lv)
+                    _pred_lv = pred_da.sel(level=_lv)
+                    _fields_lv: list[np.ndarray] = []
+                    for _li in lead_indices_g:
+                        _t = unwrap_longitude_for_plot(_reduce_grid(_tgt_lv, _li))
+                        _p = unwrap_longitude_for_plot(_reduce_grid(_pred_lv, _li))
+                        _fields_lv.append(spec["fn"](_p.values, _t.values))
+                    try:
+                        if spec["diverging"]:
+                            _abs_max = float(
+                                np.nanmax([np.nanmax(np.abs(_f)) for _f in _fields_lv])
+                            )
+                            _vmin_lv, _vmax_lv = -_abs_max, _abs_max
+                        elif spec["vmin_zero"]:
+                            _vmin_lv = 0.0
+                            _vmax_lv = float(np.nanmax([np.nanmax(_f) for _f in _fields_lv]))
+                        else:
+                            _vmin_lv = float(np.nanmin([np.nanmin(_f) for _f in _fields_lv]))
+                            _vmax_lv = float(np.nanmax([np.nanmax(_f) for _f in _fields_lv]))
+                    except ValueError:
+                        continue
+                    lev_data_g[_lv_int] = (_vmin_lv, _vmax_lv, _fields_lv)
+
+                lev_toks_g = [
+                    format_level_token(int(_lv.values) if hasattr(_lv, "values") else int(_lv))
+                    for _lv in levels
+                ]
+                lev_tok_range = (
+                    f"{lev_toks_g[0]}_to_{lev_toks_g[-1]}" if len(lev_toks_g) > 1 else lev_toks_g[0]
+                )
+
+                for i_g, (li_g, lead_str_g) in enumerate(
+                    zip(lead_indices_g, lead_labels_g, strict=False)
+                ):
+                    n_levels_g = len(levels)
+                    fig_g, axes_g = plt.subplots(
+                        n_levels_g,
+                        1,
+                        figsize=(10, 4 * n_levels_g),
+                        dpi=200,
+                        subplot_kw={"projection": ccrs.PlateCarree()},
+                        constrained_layout=True,
+                    )
+                    if n_levels_g == 1:
+                        axes_g = np.array([axes_g])
+
+                    for idx_g, _lv in enumerate(levels):
+                        _lv_int = int(_lv.values) if hasattr(_lv, "values") else int(_lv)
+                        _vmin_lv, _vmax_lv, _fields_lv = lev_data_g[_lv_int]
+                        _field = _fields_lv[i_g]
+
+                        _t_coords = unwrap_longitude_for_plot(
+                            _reduce_grid(tgt_da.sel(level=_lv), li_g)
+                        )
+                        _lon = _t_coords.coords.get("longitude", _t_coords.longitude)
+                        _lat = _t_coords.coords.get("latitude", _t_coords.latitude)
+
+                        _ax = axes_g[idx_g]
+                        _im = _ax.pcolormesh(
+                            _lon,
+                            _lat,
+                            _field,
+                            cmap=spec["cmap"],
+                            vmin=_vmin_lv,
+                            vmax=_vmax_lv,
+                            transform=ccrs.PlateCarree(),
+                            shading="auto",
+                        )
+                        _ax.coastlines(linewidth=0.5)
+                        with contextlib.suppress(Exception):
+                            _lon_v = np.asarray(_lon)
+                            _lat_v = np.asarray(_lat)
+                            _ax.set_extent(
+                                [
+                                    float(np.min(_lon_v)),
+                                    float(np.max(_lon_v)),
+                                    float(np.min(_lat_v)),
+                                    float(np.max(_lat_v)),
+                                ],
+                                crs=ccrs.PlateCarree(),
+                            )
+
+                        _lvl_label = format_level_label(_lv_int)
+                        _lead_part = f" ({lead_str_g})" if lead_str_g and idx_g == 0 else ""
+                        _init_str = ""
+                        if _init_tup_g is not None:
+                            _s, _e = _init_tup_g
+                            _init_str = f" ({_s})" if _s == _e else f" ({_s}–{_e})"
+                        _title = f"{metric_name} — {format_variable_name(str(var))}{_lvl_label}"
+                        if idx_g == 0:
+                            _title += f"{_lead_part}{_init_str}"
+                        _ax.set_title(_title)
+
+                        _cb_label = metric_name
+                        if units:
+                            _cb_label += f" [{units}]"
+                        with contextlib.suppress(Exception):
+                            fig_g.colorbar(
+                                _im,
+                                ax=_ax,
+                                orientation="horizontal",
+                                fraction=0.05,
+                                pad=0.07,
+                                label=_cb_label,
+                            )
+
+                    _lead_qual_g: str | None = None
+                    if li_g is not None and lead_vals_g is not None:
+                        _lt_g = lead_vals_g[li_g]
+                        if np.issubdtype(type(_lt_g), np.timedelta64):
+                            _h_g = int(_lt_g / np.timedelta64(1, "h"))
+                            _lead_qual_g = f"lead{_h_g:03d}h"
+
+                    _out_png_g = section_output / build_output_filename(
+                        metric=f"det_{metric_key}_map",
+                        variable=str(var),
+                        level=lev_tok_range,
+                        qualifier=_lead_qual_g,
+                        init_time_range=_init_tup_g,
+                        lead_time_range=None,
+                        ensemble=ens_token,
+                        ext="png",
+                    )
+                    save_figure(fig_g, _out_png_g, module="deterministic")
+                    plt.close(fig_g)
+
     c.success("[deterministic] Spatial metric maps generated")
 
 
@@ -348,8 +526,13 @@ def run(
     mode = str((plotting_cfg or {}).get("output_mode", "plot")).lower()
     save_fig = mode in ("plot", "both")
     save_npz = mode in ("npz", "both")
-    spatial_maps = bool(cfg.get("spatial_maps", False))
-    spatial_maps_single_mode = str(cfg.get("spatial_maps_layout", "panel")).lower() == "single"
+    spatial_maps = bool(cfg.get("error_maps", cfg.get("spatial_maps", False)))
+    spatial_maps_single_mode = (
+        str(cfg.get("error_maps_lead_layout", "stacked")).lower() == "per_lead"
+    )
+    spatial_maps_level_grid = (
+        str(cfg.get("error_maps_level_layout", "per_level")).lower() == "stacked"
+    )
     include = cfg.get("include")
     std_include = cfg.get("standardized_include")
     fss_cfg = cfg.get("fss", {})
@@ -601,6 +784,7 @@ def run(
                     save_fig=save_fig,
                     save_npz=save_npz,
                     single_map_mode=spatial_maps_single_mode,
+                    level_grid_mode=spatial_maps_level_grid,
                 )
             except Exception:
                 c.warn("[deterministic] Spatial metric map generation failed")

--- a/src/swissclim_evaluations/plots/maps.py
+++ b/src/swissclim_evaluations/plots/maps.py
@@ -547,10 +547,12 @@ def run(
                             _lev_t.min(), _lev_p.min(), _lev_t.max(), _lev_p.max()
                         )
                         _lk = int(_lev.values) if hasattr(_lev, "values") else int(_lev)
-                        lev_vmin_vmax[_lk] = (
-                            min(float(_mn_t), float(_mn_p)),
-                            max(float(_mx_t), float(_mx_p)),
-                        )
+                        _lv_min = min(float(_mn_t), float(_mn_p))
+                        _lv_max = max(float(_mx_t), float(_mx_p))
+                        if get_colormap_for_variable(str(var)) == "RdBu_r":
+                            _lv_abs = max(abs(_lv_min), abs(_lv_max))
+                            _lv_min, _lv_max = -_lv_abs, _lv_abs
+                        lev_vmin_vmax[_lk] = (_lv_min, _lv_max)
 
                     for i, lead_idx in enumerate(lead_indices_3d):
                         lead_val_3d = lead_coords_3d[i] if lead_coords_3d[i] is not None else None
@@ -724,6 +726,9 @@ def run(
                         )
                         vmin = min(float(_vmin_t), float(_vmin_p))
                         vmax = max(float(_vmax_t), float(_vmax_p))
+                        if get_colormap_for_variable(str(var)) == "RdBu_r":
+                            abs_max = max(abs(vmin), abs(vmax))
+                            vmin, vmax = -abs_max, abs_max
 
                         im0 = None
                         for i, lead_idx in enumerate(lead_indices_3d):

--- a/src/swissclim_evaluations/plots/maps.py
+++ b/src/swissclim_evaluations/plots/maps.py
@@ -41,6 +41,7 @@ def run(
         c.print("[maps] Skipping module: output_mode=none (no PNG/NPZ outputs requested).")
         return
     dpi = int(plotting_cfg.get("dpi", 48))
+    single_map_mode = str(plotting_cfg.get("maps_multi_lead_layout", "panel")).lower() == "single"
 
     section_output = out_root / "maps"
 
@@ -190,26 +191,47 @@ def run(
             )
             vmin = min(float(_vmin_t), float(_vmin_p))
             vmax = max(float(_vmax_t), float(_vmax_p))
+            if get_colormap_for_variable(str(var)) == "RdBu_r":
+                abs_max = max(abs(vmin), abs(vmax))
+                vmin, vmax = -abs_max, abs_max
 
-            fig, axes = plt.subplots(
-                n_leads,
-                2,
-                figsize=(14, 4 * n_leads),
-                dpi=dpi * 2,
-                subplot_kw={"projection": ccrs.PlateCarree()},
-                constrained_layout=True,
+            ens_token = (
+                ensemble_mode_to_token("members", ens)
+                if (resolved_mode == "members" and ens is not None)
+                else ens_token_global
             )
-            # Increase vertical spacing between rows
-            if n_leads > 1:
-                fig.get_layout_engine().set(h_pad=0.15)
 
-            if n_leads == 1:
-                axes = np.array([axes])
+            if not single_map_mode:
+                fig, axes = plt.subplots(
+                    n_leads,
+                    2,
+                    figsize=(14, 4 * n_leads),
+                    dpi=dpi * 2,
+                    subplot_kw={"projection": ccrs.PlateCarree()},
+                    constrained_layout=True,
+                )
+                if n_leads > 1:
+                    fig.get_layout_engine().set(h_pad=0.15)
+                if n_leads == 1:
+                    axes = np.array([axes])
+                im0 = None
 
-            im0 = None
             for i, lead_idx in enumerate(lead_indices):
-                ax_tgt = axes[i, 0]
-                ax_pred = axes[i, 1]
+                if single_map_mode:
+                    fig, _ax_pair = plt.subplots(
+                        1,
+                        2,
+                        figsize=(14, 4),
+                        dpi=dpi * 2,
+                        subplot_kw={"projection": ccrs.PlateCarree()},
+                        constrained_layout=True,
+                    )
+                    axes = np.array([_ax_pair])
+                    im0 = None
+
+                row = 0 if single_map_mode else i
+                ax_tgt = axes[row, 0]
+                ax_pred = axes[row, 1]
 
                 ds_var = ds_var_full
                 ds_prediction_var = ds_prediction_var_full
@@ -320,41 +342,66 @@ def run(
                 # date_str includes lead time (with '+') if target has it.
                 ax_pred.set_title(f"Prediction{ens_str}")
 
-            # Colorbar spanning both axes — vertical to save vertical space
-            cb = fig.colorbar(
-                im0,
-                ax=axes,
-                orientation="horizontal",
-                fraction=0.05,
-                pad=0.02,
-            )
-            # In test mode, colorbar may be a dummy (None); guard the label call
-            try:
-                if cb is not None:
-                    cb.set_label(get_variable_units(ds_target, str(var)))
-            except Exception:
-                # Non-fatal: continue without setting label
-                pass
+                if single_map_mode:
+                    cb = fig.colorbar(
+                        im0,
+                        ax=axes,
+                        orientation="horizontal",
+                        fraction=0.05,
+                        pad=0.02,
+                    )
+                    try:
+                        if cb is not None:
+                            cb.set_label(get_variable_units(ds_target, str(var)))
+                    except Exception:
+                        pass
+                    lead_val = lead_coords[i] if lead_coords[i] is not None else None
+                    lead_qualifier = None
+                    if lead_val is not None and np.issubdtype(type(lead_val), np.timedelta64):
+                        h = int(lead_val / np.timedelta64(1, "h"))
+                        lead_qualifier = f"lead{h:03d}h"
+                    if save_fig:
+                        out_png = section_output / build_output_filename(
+                            metric="map",
+                            variable=str(var),
+                            level="surface",
+                            qualifier=lead_qualifier,
+                            init_time_range=init_range,
+                            lead_time_range=None,
+                            ensemble=ens_token,
+                            ext="png",
+                        )
+                        save_figure(fig, out_png, module="maps")
+                    else:
+                        plt.close(fig)
 
-            ens_token = (
-                ensemble_mode_to_token("members", ens)
-                if (resolved_mode == "members" and ens is not None)
-                else ens_token_global
-            )
-            if save_fig:
-                out_png = section_output / build_output_filename(
-                    metric="map",
-                    variable=str(var),
-                    level="surface",
-                    qualifier=None,
-                    init_time_range=init_range,
-                    lead_time_range=lead_range,
-                    ensemble=ens_token,
-                    ext="png",
+            if not single_map_mode:
+                cb = fig.colorbar(
+                    im0,
+                    ax=axes,
+                    orientation="horizontal",
+                    fraction=0.05,
+                    pad=0.02,
                 )
-                save_figure(fig, out_png, module="maps")
-            else:
-                plt.close(fig)
+                try:
+                    if cb is not None:
+                        cb.set_label(get_variable_units(ds_target, str(var)))
+                except Exception:
+                    pass
+                if save_fig:
+                    out_png = section_output / build_output_filename(
+                        metric="map",
+                        variable=str(var),
+                        level="surface",
+                        qualifier=None,
+                        init_time_range=init_range,
+                        lead_time_range=lead_range,
+                        ensemble=ens_token,
+                        ext="png",
+                    )
+                    save_figure(fig, out_png, module="maps")
+                else:
+                    plt.close(fig)
             if save_npz:
                 # Prepare data for saving (full lead time stack)
                 ds_save_target = ds_var_full
@@ -490,17 +537,18 @@ def run(
                 for level in levels:
                     level_val = int(level.values) if hasattr(level, "values") else int(level)
                     n_leads_3d = len(lead_indices_3d)
-                    fig, axes = plt.subplots(
-                        n_leads_3d,
-                        2,
-                        figsize=(14, 4 * n_leads_3d),
-                        dpi=dpi * 2,
-                        subplot_kw={"projection": ccrs.PlateCarree()},
-                        squeeze=False,
-                        constrained_layout=True,
-                    )
-                    if n_leads_3d > 1:
-                        fig.get_layout_engine().set(h_pad=0.15)
+                    if not single_map_mode:
+                        fig, axes = plt.subplots(
+                            n_leads_3d,
+                            2,
+                            figsize=(14, 4 * n_leads_3d),
+                            dpi=dpi * 2,
+                            subplot_kw={"projection": ccrs.PlateCarree()},
+                            squeeze=False,
+                            constrained_layout=True,
+                        )
+                        if n_leads_3d > 1:
+                            fig.get_layout_engine().set(h_pad=0.15)
 
                     # Compute global vmin/vmax across all leads for this level
                     ds_lev_t = ds_var_full_3d.sel(level=level)
@@ -513,11 +561,26 @@ def run(
                     )
                     vmin = min(float(_vmin_t), float(_vmin_p))
                     vmax = max(float(_vmax_t), float(_vmax_p))
+                    if get_colormap_for_variable(str(var)) == "RdBu_r":
+                        abs_max = max(abs(vmin), abs(vmax))
+                        vmin, vmax = -abs_max, abs_max
 
                     im0 = None
                     for i, lead_idx in enumerate(lead_indices_3d):
-                        ax_tgt = axes[i, 0]
-                        ax_pred = axes[i, 1]
+                        if single_map_mode:
+                            fig, _ax_pair = plt.subplots(
+                                1,
+                                2,
+                                figsize=(14, 4),
+                                dpi=dpi * 2,
+                                subplot_kw={"projection": ccrs.PlateCarree()},
+                                constrained_layout=True,
+                            )
+                            axes = np.array([_ax_pair])
+                            im0 = None
+                        row = 0 if single_map_mode else i
+                        ax_tgt = axes[row, 0]
+                        ax_pred = axes[row, 1]
                         ds_t_lead = ds_lev_t
                         ds_p_lead = ds_lev_p
                         if "lead_time" in ds_t_lead.dims:
@@ -600,40 +663,84 @@ def run(
                             )
                         ax_pred.set_title(f"Prediction{ens_str}{lead_str}")
 
-                    cb = fig.colorbar(
-                        im0,
-                        ax=axes,
-                        orientation="horizontal",
-                        fraction=0.05,
-                        pad=0.02,
-                    )
-                    try:
-                        if cb is not None:
-                            cb.set_label(get_variable_units(ds_target, str(var)))
-                    except Exception:
-                        pass
+                        if single_map_mode:
+                            cb = fig.colorbar(
+                                im0,
+                                ax=axes,
+                                orientation="horizontal",
+                                fraction=0.05,
+                                pad=0.02,
+                            )
+                            try:
+                                if cb is not None:
+                                    cb.set_label(get_variable_units(ds_target, str(var)))
+                            except Exception:
+                                pass
+                            lead_val_3d = (
+                                lead_coords_3d[i] if lead_coords_3d[i] is not None else None
+                            )
+                            lead_qualifier = None
+                            if lead_val_3d is not None and np.issubdtype(
+                                type(lead_val_3d), np.timedelta64
+                            ):
+                                h = int(lead_val_3d / np.timedelta64(1, "h"))
+                                lead_qualifier = f"lead{h:03d}h"
+                            ens_token = (
+                                ensemble_mode_to_token("members", ens)
+                                if (resolved_mode == "members" and ens is not None)
+                                else ens_token_global
+                            )
+                            lev_token = format_level_token(level_val)
+                            if save_fig:
+                                out_png = section_output / build_output_filename(
+                                    metric="map",
+                                    variable=str(var),
+                                    level=lev_token,
+                                    qualifier=lead_qualifier,
+                                    init_time_range=init_range,
+                                    lead_time_range=None,
+                                    ensemble=ens_token,
+                                    ext="png",
+                                )
+                                save_figure(fig, out_png, module="maps")
+                            else:
+                                plt.close(fig)
 
-                    ens_token = (
-                        ensemble_mode_to_token("members", ens)
-                        if (resolved_mode == "members" and ens is not None)
-                        else ens_token_global
-                    )
-                    lev_token = format_level_token(level_val)
-                    if save_fig:
-                        out_png = section_output / build_output_filename(
-                            metric="map",
-                            variable=str(var),
-                            level=lev_token,
-                            qualifier=None,
-                            init_time_range=init_range,
-                            lead_time_range=lead_range,
-                            ensemble=ens_token,
-                            ext="png",
+                    if not single_map_mode:
+                        cb = fig.colorbar(
+                            im0,
+                            ax=axes,
+                            orientation="horizontal",
+                            fraction=0.05,
+                            pad=0.02,
                         )
-                        save_figure(fig, out_png, module="maps")
-                    else:
+                        try:
+                            if cb is not None:
+                                cb.set_label(get_variable_units(ds_target, str(var)))
+                        except Exception:
+                            pass
+
+                        ens_token = (
+                            ensemble_mode_to_token("members", ens)
+                            if (resolved_mode == "members" and ens is not None)
+                            else ens_token_global
+                        )
+                        lev_token = format_level_token(level_val)
+                        if save_fig:
+                            out_png = section_output / build_output_filename(
+                                metric="map",
+                                variable=str(var),
+                                level=lev_token,
+                                qualifier=None,
+                                init_time_range=init_range,
+                                lead_time_range=lead_range,
+                                ensemble=ens_token,
+                                ext="png",
+                            )
+                            save_figure(fig, out_png, module="maps")
+                        else:
+                            plt.close(fig)
                         plt.close(fig)
-                    plt.close(fig)
             else:
                 # Single-lead: original all-levels-in-one-figure layout
                 num_rows = len(levels)
@@ -666,6 +773,9 @@ def run(
                     arr_p = ds_prediction_var_lev.values
                     vmin = min(float(np.nanmin(arr_t)), float(np.nanmin(arr_p)))
                     vmax = max(float(np.nanmax(arr_t)), float(np.nanmax(arr_p)))
+                    if get_colormap_for_variable(str(var)) == "RdBu_r":
+                        abs_max = max(abs(vmin), abs(vmax))
+                        vmin, vmax = -abs_max, abs_max
 
                     im_ds = ax_ds.pcolormesh(
                         ds_var_lev.coords.get("longitude"),

--- a/src/swissclim_evaluations/plots/maps.py
+++ b/src/swissclim_evaluations/plots/maps.py
@@ -41,7 +41,8 @@ def run(
         c.print("[maps] Skipping module: output_mode=none (no PNG/NPZ outputs requested).")
         return
     dpi = int(plotting_cfg.get("dpi", 48))
-    single_map_mode = str(plotting_cfg.get("maps_multi_lead_layout", "panel")).lower() == "single"
+    single_map_mode = str(plotting_cfg.get("maps_lead_layout", "stacked")).lower() == "per_lead"
+    level_grid_mode = str(plotting_cfg.get("maps_level_layout", "per_level")).lower() == "stacked"
 
     section_output = out_root / "maps"
 
@@ -191,9 +192,6 @@ def run(
             )
             vmin = min(float(_vmin_t), float(_vmin_p))
             vmax = max(float(_vmax_t), float(_vmax_p))
-            if get_colormap_for_variable(str(var)) == "RdBu_r":
-                abs_max = max(abs(vmin), abs(vmax))
-                vmin, vmax = -abs_max, abs_max
 
             ens_token = (
                 ensemble_mode_to_token("members", ens)
@@ -298,8 +296,10 @@ def run(
                     else:
                         lead_str = f" (lead={val})"
 
-                date_str = extract_date_from_dataset(ds_var) if is_single_init else ""
-                if i == 0:
+                date_str = (
+                    extract_date_from_dataset(ds_var) if (is_single_init or single_map_mode) else ""
+                )
+                if i == 0 or single_map_mode:
                     ax_tgt.set_title(f"{format_variable_name(str(var))} — Target{date_str}")
                 else:
                     ax_tgt.set_title(f"Target{lead_str}")
@@ -338,9 +338,7 @@ def run(
                         ],
                         crs=ccrs.PlateCarree(),
                     )
-                # Only show lead time on prediction if not already in target title (via date_str)
-                # date_str includes lead time (with '+') if target has it.
-                ax_pred.set_title(f"Prediction{ens_str}")
+                ax_pred.set_title(f"Prediction{ens_str}{lead_str if single_map_mode else ''}")
 
                 if single_map_mode:
                     cb = fig.colorbar(
@@ -533,137 +531,347 @@ def run(
             ens_str = f" (member {ens})" if ens is not None else ""
 
             if has_multi_lead_3d:
-                # Multi-lead: one lead-time gridded figure per level
-                for level in levels:
-                    level_val = int(level.values) if hasattr(level, "values") else int(level)
-                    n_leads_3d = len(lead_indices_3d)
-                    if not single_map_mode:
-                        fig, axes = plt.subplots(
-                            n_leads_3d,
-                            2,
-                            figsize=(14, 4 * n_leads_3d),
-                            dpi=dpi * 2,
-                            subplot_kw={"projection": ccrs.PlateCarree()},
-                            squeeze=False,
-                            constrained_layout=True,
+                if single_map_mode and level_grid_mode:
+                    # ── Grid mode: one figure per lead, all pressure levels as rows ──
+                    # Colour scale is fixed per level across all lead frames so that
+                    # animating (GIF) gives a consistent visual comparison.
+                    n_levels_3d = len(levels)
+                    lev_vmin_vmax: dict[int, tuple[float, float]] = {}
+                    for _lev in levels:
+                        _lev_t = ds_var_full_3d.sel(level=_lev)
+                        _lev_p = ds_prediction_var_full_3d.sel(level=_lev)
+                        _mn_t, _mn_p, _mx_t, _mx_p = dask.compute(
+                            _lev_t.min(), _lev_p.min(), _lev_t.max(), _lev_p.max()
                         )
-                        if n_leads_3d > 1:
-                            fig.get_layout_engine().set(h_pad=0.15)
+                        _lk = int(_lev.values) if hasattr(_lev, "values") else int(_lev)
+                        lev_vmin_vmax[_lk] = (
+                            min(float(_mn_t), float(_mn_p)),
+                            max(float(_mx_t), float(_mx_p)),
+                        )
 
-                    # Compute global vmin/vmax across all leads for this level
-                    ds_lev_t = ds_var_full_3d.sel(level=level)
-                    ds_lev_p = ds_prediction_var_full_3d.sel(level=level)
-                    _vmin_t, _vmin_p, _vmax_t, _vmax_p = dask.compute(
-                        ds_lev_t.min(),
-                        ds_lev_p.min(),
-                        ds_lev_t.max(),
-                        ds_lev_p.max(),
-                    )
-                    vmin = min(float(_vmin_t), float(_vmin_p))
-                    vmax = max(float(_vmax_t), float(_vmax_p))
-                    if get_colormap_for_variable(str(var)) == "RdBu_r":
-                        abs_max = max(abs(vmin), abs(vmax))
-                        vmin, vmax = -abs_max, abs_max
-
-                    im0 = None
                     for i, lead_idx in enumerate(lead_indices_3d):
-                        if single_map_mode:
-                            fig, _ax_pair = plt.subplots(
-                                1,
+                        lead_val_3d = lead_coords_3d[i] if lead_coords_3d[i] is not None else None
+                        lead_str = ""
+                        lead_qualifier = None
+                        if lead_val_3d is not None and np.issubdtype(
+                            type(lead_val_3d), np.timedelta64
+                        ):
+                            h_lead = int(lead_val_3d / np.timedelta64(1, "h"))
+                            lead_str = f" (+{h_lead}h)"
+                            lead_qualifier = f"lead{h_lead:03d}h"
+
+                        if save_fig:
+                            fig, axes = plt.subplots(
+                                n_levels_3d,
                                 2,
-                                figsize=(14, 4),
+                                figsize=(14, 4 * n_levels_3d),
                                 dpi=dpi * 2,
                                 subplot_kw={"projection": ccrs.PlateCarree()},
+                                squeeze=False,
                                 constrained_layout=True,
                             )
-                            axes = np.array([_ax_pair])
-                            im0 = None
-                        row = 0 if single_map_mode else i
-                        ax_tgt = axes[row, 0]
-                        ax_pred = axes[row, 1]
-                        ds_t_lead = ds_lev_t
-                        ds_p_lead = ds_lev_p
-                        if "lead_time" in ds_t_lead.dims:
-                            ds_t_lead = ds_t_lead.isel(lead_time=lead_idx)
-                        if "lead_time" in ds_p_lead.dims:
-                            ds_p_lead = ds_p_lead.isel(lead_time=lead_idx)
-                        ds_t_lead = ds_t_lead.squeeze()
-                        ds_p_lead = ds_p_lead.squeeze()
-                        ds_t_lead = unwrap_longitude_for_plot(ds_t_lead)
-                        ds_p_lead = unwrap_longitude_for_plot(ds_p_lead)
+                            if n_levels_3d > 1:
+                                fig.get_layout_engine().set(h_pad=0.15)
 
-                        lon = ds_t_lead.coords.get("longitude", None)
-                        lat = ds_t_lead.coords.get("latitude", None)
-                        im0 = ax_tgt.pcolormesh(
-                            lon if lon is not None else ds_t_lead.longitude,
-                            lat if lat is not None else ds_t_lead.latitude,
-                            ds_t_lead.values,
-                            cmap=get_colormap_for_variable(str(var)),
-                            vmin=vmin,
-                            vmax=vmax,
-                            transform=ccrs.PlateCarree(),
-                            shading="auto",
+                        for idx, level in enumerate(levels):
+                            level_val = (
+                                int(level.values) if hasattr(level, "values") else int(level)
+                            )
+                            lev_vmin, lev_vmax = lev_vmin_vmax[level_val]
+
+                            ds_t_ll = ds_var_full_3d.sel(level=level)
+                            ds_p_ll = ds_prediction_var_full_3d.sel(level=level)
+                            if "lead_time" in ds_t_ll.dims:
+                                ds_t_ll = ds_t_ll.isel(lead_time=lead_idx)
+                            if "lead_time" in ds_p_ll.dims:
+                                ds_p_ll = ds_p_ll.isel(lead_time=lead_idx)
+                            ds_t_ll = ds_t_ll.squeeze()
+                            ds_p_ll = ds_p_ll.squeeze()
+                            ds_t_ll = unwrap_longitude_for_plot(ds_t_ll)
+                            ds_p_ll = unwrap_longitude_for_plot(ds_p_ll)
+
+                            if save_fig:
+                                ax_tgt = axes[idx, 0]
+                                ax_pred = axes[idx, 1]
+                                lon = ds_t_ll.coords.get("longitude", None)
+                                lat = ds_t_ll.coords.get("latitude", None)
+                                im_row = ax_tgt.pcolormesh(
+                                    lon if lon is not None else ds_t_ll.longitude,
+                                    lat if lat is not None else ds_t_ll.latitude,
+                                    ds_t_ll.values,
+                                    cmap=get_colormap_for_variable(str(var)),
+                                    vmin=lev_vmin,
+                                    vmax=lev_vmax,
+                                    transform=ccrs.PlateCarree(),
+                                    shading="auto",
+                                )
+                                ax_tgt.coastlines(linewidth=0.5)
+                                _lon = lon.values if lon is not None else ds_t_ll.longitude.values
+                                _lat = lat.values if lat is not None else ds_t_ll.latitude.values
+                                if hasattr(ax_tgt, "set_extent"):
+                                    ax_tgt.set_extent(
+                                        [
+                                            float(np.min(_lon)),
+                                            float(np.max(_lon)),
+                                            float(np.min(_lat)),
+                                            float(np.max(_lat)),
+                                        ],
+                                        crs=ccrs.PlateCarree(),
+                                    )
+                                # Row 0: variable name + lead + init; other rows: level only
+                                date_str = extract_date_from_dataset(ds_t_ll)
+                                if idx == 0:
+                                    ax_tgt.set_title(
+                                        f"{format_variable_name(str(var))} — Target"
+                                        f"{format_level_label(level_val)}"
+                                        f"{lead_str}{date_str}"
+                                    )
+                                else:
+                                    ax_tgt.set_title(f"Target{format_level_label(level_val)}")
+                                lon_p = ds_p_ll.coords.get("longitude", None)
+                                lat_p = ds_p_ll.coords.get("latitude", None)
+                                ax_pred.pcolormesh(
+                                    lon_p if lon_p is not None else ds_p_ll.longitude,
+                                    lat_p if lat_p is not None else ds_p_ll.latitude,
+                                    ds_p_ll.values,
+                                    cmap=get_colormap_for_variable(str(var)),
+                                    vmin=lev_vmin,
+                                    vmax=lev_vmax,
+                                    transform=ccrs.PlateCarree(),
+                                    shading="auto",
+                                )
+                                ax_pred.coastlines(linewidth=0.5)
+                                _lon_p = (
+                                    lon_p.values if lon_p is not None else ds_p_ll.longitude.values
+                                )
+                                _lat_p = (
+                                    lat_p.values if lat_p is not None else ds_p_ll.latitude.values
+                                )
+                                if hasattr(ax_pred, "set_extent"):
+                                    ax_pred.set_extent(
+                                        [
+                                            float(np.min(_lon_p)),
+                                            float(np.max(_lon_p)),
+                                            float(np.min(_lat_p)),
+                                            float(np.max(_lat_p)),
+                                        ],
+                                        crs=ccrs.PlateCarree(),
+                                    )
+                                pred_lead = lead_str if idx == 0 else ""
+                                ax_pred.set_title(
+                                    f"Prediction{format_level_label(level_val)}"
+                                    f"{ens_str}{pred_lead}"
+                                )
+                                # Per-row colorbar — level scale stays fixed across leads
+                                fig.colorbar(
+                                    im_row,
+                                    ax=[ax_tgt, ax_pred],
+                                    orientation="horizontal",
+                                    fraction=0.05,
+                                    pad=0.07,
+                                    label=get_variable_units(ds_target, str(var)),
+                                )
+
+                        ens_token = (
+                            ensemble_mode_to_token("members", ens)
+                            if (resolved_mode == "members" and ens is not None)
+                            else ens_token_global
                         )
-                        ax_tgt.coastlines(linewidth=0.5)
-                        _lon = lon.values if lon is not None else ds_t_lead.longitude.values
-                        _lat = lat.values if lat is not None else ds_t_lead.latitude.values
-                        if hasattr(ax_tgt, "set_extent"):
-                            ax_tgt.set_extent(
-                                [
-                                    float(np.min(_lon)),
-                                    float(np.max(_lon)),
-                                    float(np.min(_lat)),
-                                    float(np.max(_lat)),
-                                ],
-                                crs=ccrs.PlateCarree(),
+                        if save_fig:
+                            out_png = section_output / build_output_filename(
+                                metric="map",
+                                variable=str(var),
+                                level=level_label,
+                                qualifier=lead_qualifier,
+                                init_time_range=init_range,
+                                lead_time_range=None,
+                                ensemble=ens_token,
+                                ext="png",
                             )
-
-                        lead_str = ""
-                        if lead_coords_3d[i] is not None:
-                            val = lead_coords_3d[i]
-                            if np.issubdtype(type(val), np.timedelta64):
-                                h = int(val / np.timedelta64(1, "h"))
-                                lead_str = f" (+{h}h)"
-                            else:
-                                lead_str = f" (lead={val})"
-
-                        date_str = extract_date_from_dataset(ds_t_lead) if is_single_init else ""
-                        if i == 0:
-                            ax_tgt.set_title(
-                                f"{format_variable_name(str(var))} — Target"
-                                f"{format_level_label(level_val)}{date_str}"
-                            )
+                            save_figure(fig, out_png, module="maps")
                         else:
-                            ax_tgt.set_title(f"Target{lead_str}")
+                            plt.close(fig)
 
-                        lon_p = ds_p_lead.coords.get("longitude", None)
-                        lat_p = ds_p_lead.coords.get("latitude", None)
-                        ax_pred.pcolormesh(
-                            lon_p if lon_p is not None else ds_p_lead.longitude,
-                            lat_p if lat_p is not None else ds_p_lead.latitude,
-                            ds_p_lead.values,
-                            cmap=get_colormap_for_variable(str(var)),
-                            vmin=vmin,
-                            vmax=vmax,
-                            transform=ccrs.PlateCarree(),
-                            shading="auto",
-                        )
-                        ax_pred.coastlines(linewidth=0.5)
-                        _lon_p = lon_p.values if lon_p is not None else ds_p_lead.longitude.values
-                        _lat_p = lat_p.values if lat_p is not None else ds_p_lead.latitude.values
-                        if hasattr(ax_pred, "set_extent"):
-                            ax_pred.set_extent(
-                                [
-                                    float(np.min(_lon_p)),
-                                    float(np.max(_lon_p)),
-                                    float(np.min(_lat_p)),
-                                    float(np.max(_lat_p)),
-                                ],
-                                crs=ccrs.PlateCarree(),
+                else:
+                    # Existing: outer loop over levels (panel or per-level-single modes)
+                    for level in levels:
+                        level_val = int(level.values) if hasattr(level, "values") else int(level)
+                        n_leads_3d = len(lead_indices_3d)
+                        if not single_map_mode:
+                            fig, axes = plt.subplots(
+                                n_leads_3d,
+                                2,
+                                figsize=(14, 4 * n_leads_3d),
+                                dpi=dpi * 2,
+                                subplot_kw={"projection": ccrs.PlateCarree()},
+                                squeeze=False,
+                                constrained_layout=True,
                             )
-                        ax_pred.set_title(f"Prediction{ens_str}{lead_str}")
+                            if n_leads_3d > 1:
+                                fig.get_layout_engine().set(h_pad=0.15)
 
-                        if single_map_mode:
+                        # Compute global vmin/vmax across all leads for this level
+                        ds_lev_t = ds_var_full_3d.sel(level=level)
+                        ds_lev_p = ds_prediction_var_full_3d.sel(level=level)
+                        _vmin_t, _vmin_p, _vmax_t, _vmax_p = dask.compute(
+                            ds_lev_t.min(),
+                            ds_lev_p.min(),
+                            ds_lev_t.max(),
+                            ds_lev_p.max(),
+                        )
+                        vmin = min(float(_vmin_t), float(_vmin_p))
+                        vmax = max(float(_vmax_t), float(_vmax_p))
+
+                        im0 = None
+                        for i, lead_idx in enumerate(lead_indices_3d):
+                            if single_map_mode:
+                                fig, _ax_pair = plt.subplots(
+                                    1,
+                                    2,
+                                    figsize=(14, 4),
+                                    dpi=dpi * 2,
+                                    subplot_kw={"projection": ccrs.PlateCarree()},
+                                    constrained_layout=True,
+                                )
+                                axes = np.array([_ax_pair])
+                                im0 = None
+                            row = 0 if single_map_mode else i
+                            ax_tgt = axes[row, 0]
+                            ax_pred = axes[row, 1]
+                            ds_t_lead = ds_lev_t
+                            ds_p_lead = ds_lev_p
+                            if "lead_time" in ds_t_lead.dims:
+                                ds_t_lead = ds_t_lead.isel(lead_time=lead_idx)
+                            if "lead_time" in ds_p_lead.dims:
+                                ds_p_lead = ds_p_lead.isel(lead_time=lead_idx)
+                            ds_t_lead = ds_t_lead.squeeze()
+                            ds_p_lead = ds_p_lead.squeeze()
+                            ds_t_lead = unwrap_longitude_for_plot(ds_t_lead)
+                            ds_p_lead = unwrap_longitude_for_plot(ds_p_lead)
+
+                            lon = ds_t_lead.coords.get("longitude", None)
+                            lat = ds_t_lead.coords.get("latitude", None)
+                            im0 = ax_tgt.pcolormesh(
+                                lon if lon is not None else ds_t_lead.longitude,
+                                lat if lat is not None else ds_t_lead.latitude,
+                                ds_t_lead.values,
+                                cmap=get_colormap_for_variable(str(var)),
+                                vmin=vmin,
+                                vmax=vmax,
+                                transform=ccrs.PlateCarree(),
+                                shading="auto",
+                            )
+                            ax_tgt.coastlines(linewidth=0.5)
+                            _lon = lon.values if lon is not None else ds_t_lead.longitude.values
+                            _lat = lat.values if lat is not None else ds_t_lead.latitude.values
+                            if hasattr(ax_tgt, "set_extent"):
+                                ax_tgt.set_extent(
+                                    [
+                                        float(np.min(_lon)),
+                                        float(np.max(_lon)),
+                                        float(np.min(_lat)),
+                                        float(np.max(_lat)),
+                                    ],
+                                    crs=ccrs.PlateCarree(),
+                                )
+
+                            lead_str = ""
+                            if lead_coords_3d[i] is not None:
+                                val = lead_coords_3d[i]
+                                if np.issubdtype(type(val), np.timedelta64):
+                                    h = int(val / np.timedelta64(1, "h"))
+                                    lead_str = f" (+{h}h)"
+                                else:
+                                    lead_str = f" (lead={val})"
+
+                            date_str = (
+                                extract_date_from_dataset(ds_t_lead)
+                                if (is_single_init or single_map_mode)
+                                else ""
+                            )
+                            if i == 0 or single_map_mode:
+                                ax_tgt.set_title(
+                                    f"{format_variable_name(str(var))} — Target"
+                                    f"{format_level_label(level_val)}{date_str}"
+                                )
+                            else:
+                                ax_tgt.set_title(f"Target{lead_str}")
+
+                            lon_p = ds_p_lead.coords.get("longitude", None)
+                            lat_p = ds_p_lead.coords.get("latitude", None)
+                            ax_pred.pcolormesh(
+                                lon_p if lon_p is not None else ds_p_lead.longitude,
+                                lat_p if lat_p is not None else ds_p_lead.latitude,
+                                ds_p_lead.values,
+                                cmap=get_colormap_for_variable(str(var)),
+                                vmin=vmin,
+                                vmax=vmax,
+                                transform=ccrs.PlateCarree(),
+                                shading="auto",
+                            )
+                            ax_pred.coastlines(linewidth=0.5)
+                            _lon_p = (
+                                lon_p.values if lon_p is not None else ds_p_lead.longitude.values
+                            )
+                            _lat_p = (
+                                lat_p.values if lat_p is not None else ds_p_lead.latitude.values
+                            )
+                            if hasattr(ax_pred, "set_extent"):
+                                ax_pred.set_extent(
+                                    [
+                                        float(np.min(_lon_p)),
+                                        float(np.max(_lon_p)),
+                                        float(np.min(_lat_p)),
+                                        float(np.max(_lat_p)),
+                                    ],
+                                    crs=ccrs.PlateCarree(),
+                                )
+                            ax_pred.set_title(f"Prediction{ens_str}{lead_str}")
+
+                            if single_map_mode:
+                                cb = fig.colorbar(
+                                    im0,
+                                    ax=axes,
+                                    orientation="horizontal",
+                                    fraction=0.05,
+                                    pad=0.02,
+                                )
+                                try:
+                                    if cb is not None:
+                                        cb.set_label(get_variable_units(ds_target, str(var)))
+                                except Exception:
+                                    pass
+                                lead_val_3d = (
+                                    lead_coords_3d[i] if lead_coords_3d[i] is not None else None
+                                )
+                                lead_qualifier = None
+                                if lead_val_3d is not None and np.issubdtype(
+                                    type(lead_val_3d), np.timedelta64
+                                ):
+                                    h = int(lead_val_3d / np.timedelta64(1, "h"))
+                                    lead_qualifier = f"lead{h:03d}h"
+                                ens_token = (
+                                    ensemble_mode_to_token("members", ens)
+                                    if (resolved_mode == "members" and ens is not None)
+                                    else ens_token_global
+                                )
+                                lev_token = format_level_token(level_val)
+                                if save_fig:
+                                    out_png = section_output / build_output_filename(
+                                        metric="map",
+                                        variable=str(var),
+                                        level=lev_token,
+                                        qualifier=lead_qualifier,
+                                        init_time_range=init_range,
+                                        lead_time_range=None,
+                                        ensemble=ens_token,
+                                        ext="png",
+                                    )
+                                    save_figure(fig, out_png, module="maps")
+                                else:
+                                    plt.close(fig)
+
+                        if not single_map_mode:
                             cb = fig.colorbar(
                                 im0,
                                 ax=axes,
@@ -676,15 +884,7 @@ def run(
                                     cb.set_label(get_variable_units(ds_target, str(var)))
                             except Exception:
                                 pass
-                            lead_val_3d = (
-                                lead_coords_3d[i] if lead_coords_3d[i] is not None else None
-                            )
-                            lead_qualifier = None
-                            if lead_val_3d is not None and np.issubdtype(
-                                type(lead_val_3d), np.timedelta64
-                            ):
-                                h = int(lead_val_3d / np.timedelta64(1, "h"))
-                                lead_qualifier = f"lead{h:03d}h"
+
                             ens_token = (
                                 ensemble_mode_to_token("members", ens)
                                 if (resolved_mode == "members" and ens is not None)
@@ -696,51 +896,16 @@ def run(
                                     metric="map",
                                     variable=str(var),
                                     level=lev_token,
-                                    qualifier=lead_qualifier,
+                                    qualifier=None,
                                     init_time_range=init_range,
-                                    lead_time_range=None,
+                                    lead_time_range=lead_range,
                                     ensemble=ens_token,
                                     ext="png",
                                 )
                                 save_figure(fig, out_png, module="maps")
                             else:
                                 plt.close(fig)
-
-                    if not single_map_mode:
-                        cb = fig.colorbar(
-                            im0,
-                            ax=axes,
-                            orientation="horizontal",
-                            fraction=0.05,
-                            pad=0.02,
-                        )
-                        try:
-                            if cb is not None:
-                                cb.set_label(get_variable_units(ds_target, str(var)))
-                        except Exception:
-                            pass
-
-                        ens_token = (
-                            ensemble_mode_to_token("members", ens)
-                            if (resolved_mode == "members" and ens is not None)
-                            else ens_token_global
-                        )
-                        lev_token = format_level_token(level_val)
-                        if save_fig:
-                            out_png = section_output / build_output_filename(
-                                metric="map",
-                                variable=str(var),
-                                level=lev_token,
-                                qualifier=None,
-                                init_time_range=init_range,
-                                lead_time_range=lead_range,
-                                ensemble=ens_token,
-                                ext="png",
-                            )
-                            save_figure(fig, out_png, module="maps")
-                        else:
                             plt.close(fig)
-                        plt.close(fig)
             else:
                 # Single-lead: original all-levels-in-one-figure layout
                 num_rows = len(levels)
@@ -773,9 +938,6 @@ def run(
                     arr_p = ds_prediction_var_lev.values
                     vmin = min(float(np.nanmin(arr_t)), float(np.nanmin(arr_p)))
                     vmax = max(float(np.nanmax(arr_t)), float(np.nanmax(arr_p)))
-                    if get_colormap_for_variable(str(var)) == "RdBu_r":
-                        abs_max = max(abs(vmin), abs(vmax))
-                        vmin, vmax = -abs_max, abs_max
 
                     im_ds = ax_ds.pcolormesh(
                         ds_var_lev.coords.get("longitude"),

--- a/tests/test_diverging_colorbar.py
+++ b/tests/test_diverging_colorbar.py
@@ -8,6 +8,7 @@ vmin == -vmax.
 The conftest autouse fixture _fast_plots replaces plt.subplots with
 _DummyAxis objects, so we intercept _DummyAxis.pcolormesh to capture calls.
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -16,10 +17,10 @@ import xarray as xr
 
 from tests.conftest import _DummyAxis
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_wind_ds(lo: float = -1.0, hi: float = 8.0) -> xr.Dataset:
     """Tiny (1 time × 2 lat × 2 lon) wind dataset with values in [lo, hi]."""
@@ -74,6 +75,7 @@ def _capture_pcolormesh(monkeypatch):
 # Tests
 # ---------------------------------------------------------------------------
 
+
 def test_diverging_colorbar_symmetric_for_wind_field(tmp_path, monkeypatch):
     """pcolormesh vmin/vmax must be symmetric around 0 for wind (RdBu_r) fields.
 
@@ -96,9 +98,7 @@ def test_diverging_colorbar_symmetric_for_wind_field(tmp_path, monkeypatch):
     for kwargs in captured:
         vmin, vmax = kwargs.get("vmin"), kwargs.get("vmax")
         assert vmin is not None and vmax is not None
-        assert vmin == pytest.approx(-vmax), (
-            f"Colorbar not centred at 0: vmin={vmin}, vmax={vmax}"
-        )
+        assert vmin == pytest.approx(-vmax), f"Colorbar not centred at 0: vmin={vmin}, vmax={vmax}"
 
 
 def test_non_diverging_colorbar_not_forced_symmetric(tmp_path, monkeypatch):
@@ -119,6 +119,6 @@ def test_non_diverging_colorbar_not_forced_symmetric(tmp_path, monkeypatch):
     for kwargs in captured:
         vmin = kwargs.get("vmin")
         # Temperature range is [270, 300] — vmin must remain positive
-        assert vmin is not None and vmin > 0, (
-            f"Temperature colorbar was wrongly forced negative: vmin={vmin}"
-        )
+        assert (
+            vmin is not None and vmin > 0
+        ), f"Temperature colorbar was wrongly forced negative: vmin={vmin}"


### PR DESCRIPTION
I think the best way to introduce per lead_time plots is to clean up the flags in the config yaml file. Without changing the defaults and assuring full backward compatibility, map creation is now more flexbible AND more intuitive. Maps are created by the `maps` and the `deterministics` module (so called maps and error maps). Both of these modules now contain a `*_lead_layout` and `*_level_layout`  config flag. This is how they behave. If you want gif-ready output make sure to chose appropriately:

| `*_lead_layout` | `*_level_layout` | Output for a 3D multi-lead run | GIF-ready? |
|---|---|---|---|
| `stacked` | `per_level` | One figure per level, rows = lead times (default) | No — one file per level, not per time step |
| `stacked` | `stacked` | Same as above — level flag has no effect in lead-stacked mode | No |
| `per_lead` | `per_level` | One PNG per lead **per level** | Yes — one GIF per level |
| `per_lead` | `stacked` | **One PNG per lead, all levels as rows** | Yes — one combined GIF |

Prediction/Target zarr that don't feature multi level or lead_time dimensions will silenty ignore meaningless user config flags :see_no_evil: 