### PR TITLE
added per lead output options for energy spectra

### DIFF
--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -329,6 +329,13 @@ metrics:
     # the spectrograms already summarise the full lead-time evolution in one figure.
     individual_plots: false
 
+    # Per-lead energy spectrum layout for multi-lead runs.
+    # overlay: one plot with all lead times as colored lines (one figure per variable)
+    # single:  one plot per lead time, all sharing the same y-axis limits (GIF-ready)
+    # both:    generate both outputs (default)
+    # none:    disable per-lead spectrum plots
+    per_lead_spectra_layout: none  # overlay | single | both | none
+
     # Note: wind-speed variables (wind_speed, 10m_wind_speed) receive automatic
     # kinetic-energy proxy treatment:  KE = 0.5 * (|FFT(U)|² + |FFT(V)|²)
     # instead of the spectrum of the scalar wind-speed field, which would be

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -336,6 +336,10 @@ metrics:
     # none:    disable per-lead spectrum plots
     per_lead_spectra_layout: none  # overlay | single | both | none
 
+    # Annotation toggles — set to false to produce cleaner plots for presentations.
+    # show_4dx_cutoff: true   # gold dotted vertical line at the 4Δx effective resolution limit
+    # show_lsd: true          # "LSD = X.XXXX" text box in the lower centre of each spectrum plot
+
     # Note: wind-speed variables (wind_speed, 10m_wind_speed) receive automatic
     # kinetic-energy proxy treatment:  KE = 0.5 * (|FFT(U)|² + |FFT(V)|²)
     # instead of the spectrum of the scalar wind-speed field, which would be

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -157,6 +157,15 @@ is exported per init_time/lead_time and summarized. Outputs are split into singl
 - `both` — produce both outputs above.
 - `none` (default) — disable per-lead spectrum plots.
 
+**Annotation toggles** (`metrics.energy_spectra`):
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `show_4dx_cutoff` | `true` | Gold dotted vertical line marking the 4Δx effective-resolution cutoff. Set to `false` for cleaner presentation plots. |
+| `show_lsd` | `true` | "LSD = X.XXXX" text annotation in the lower centre of each spectrum plot. Set to `false` to omit the metric from the figure. |
+
+Both flags apply to all spectrum plot types (averaged, per-lead overlay, per-lead single) as well as the intercomparison overlay plots if applicable. LSD values are always written to CSV regardless of `show_lsd`.
+
 Both 2D surface variables and 3D pressure-level variables are supported; 3D filenames
 include the level (e.g. `_500hPa_`).
 

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -141,10 +141,24 @@ is exported per init_time/lead_time and summarized. Outputs are split into singl
 
 **Per Lead (Multi Lead):**
 
-- Spectrograms: `energy_spectra/energy_spectra_per_lead_<variable>...`
+- Spectrograms (tripanel): `energy_spectra/energy_spectra_per_lead_<variable>_tripanel_...png`
 - LSD per-lead (2D): `energy_spectra/energy_ratios_per_lead_by_lead_long_<range>.csv` (and wide format)
 - LSD Banded per-lead: `energy_spectra/energy_ratios_bands_per_lead_per_lead_time_<range>.csv`
 - LSD Line Plot: `energy_spectra/energy_ratios_line_per_lead_<variable>...`
+
+**Per-lead energy spectrum plots** (controlled by `metrics.energy_spectra.per_lead_spectra_layout`):
+
+- `overlay` — one PNG per variable with all lead times as colored lines (plasma colormap,
+  solid = target, dashed = prediction); colorbar shows lead time in hours.
+  Filename: `energy_spectra/energy_spectra_per_lead_<variable>_overlay_...png`
+- `single` — one PNG per lead time, all sharing global y-axis limits so frames can be
+  assembled into a GIF.
+  Filename: `energy_spectra/energy_spectrum_<variable>_lead<NNN>h_...png`
+- `both` — produce both outputs above.
+- `none` (default) — disable per-lead spectrum plots.
+
+Both 2D surface variables and 3D pressure-level variables are supported; 3D filenames
+include the level (e.g. `_500hPa_`).
 
 ### Distribution Analysis (Histograms & KDE / Wasserstein)
 

--- a/src/swissclim_evaluations/intercompare.py
+++ b/src/swissclim_evaluations/intercompare.py
@@ -255,6 +255,7 @@ def run_from_config(cfg: dict) -> None:
     # Energy spectra individual plots flag (default: False — only spectrograms for multi-lead)
     spectra_cfg = (cfg.get("metrics") or {}).get("energy_spectra") or {}
     energy_spectra_individual_plots = bool(spectra_cfg.get("individual_plots", False))
+    energy_spectra_show_4dx_cutoff = bool(spectra_cfg.get("show_4dx_cutoff", True))
 
     # Light validation: warn on missing model dirs
     for m in models:
@@ -280,7 +281,11 @@ def run_from_config(cfg: dict) -> None:
         intercompare_wd_kde(models, labels, out_root)
     if "spectra" in mods:
         intercompare_energy_spectra(
-            models, labels, out_root, individual_plots=energy_spectra_individual_plots
+            models,
+            labels,
+            out_root,
+            individual_plots=energy_spectra_individual_plots,
+            show_4dx_cutoff=energy_spectra_show_4dx_cutoff,
         )
     if "vprof" in mods:
         intercompare_vertical_profiles(models, labels, out_root)

--- a/src/swissclim_evaluations/intercomparison/modules/energy_spectra.py
+++ b/src/swissclim_evaluations/intercomparison/modules/energy_spectra.py
@@ -199,6 +199,7 @@ def intercompare_energy_spectra(
     out_root: Path,
     *,
     individual_plots: bool = False,
+    show_4dx_cutoff: bool = True,
 ) -> None:
     """Overlay energy spectra (and ratios) from multiple models.
 
@@ -576,7 +577,7 @@ def intercompare_energy_spectra(
 
             # Add golden dotted line at 4*dx cutoff (k_max / 2)
             # We assume all models have roughly the same resolution/grid
-            if wn is not None:
+            if show_4dx_cutoff and wn is not None:
                 k_max_inter = float(np.nanmax(wn))
                 # Validation: only plot cutoff if k_max_inter is finite and > 0
                 if np.isfinite(k_max_inter) and k_max_inter > 0:

--- a/src/swissclim_evaluations/plots/energy_spectra.py
+++ b/src/swissclim_evaluations/plots/energy_spectra.py
@@ -786,6 +786,212 @@ def _plot_averaged_spectra(
         )
 
 
+def _plot_per_lead_spectra_overlay(
+    spec_t: xr.DataArray,
+    spec_p: xr.DataArray,
+    var: str,
+    level: int | None,
+    x_hours: np.ndarray,
+    out_dir: Path,
+    init_range: tuple[str, str] | None,
+    lead_range: tuple[str, str] | None,
+    ens_token: str | None,
+    dpi: int,
+) -> None:
+    """One PNG with one colored line per lead_time for both target and prediction.
+
+    Colors run from violet (short lead) to yellow (long lead) via ``viridis``.
+    Solid lines = target, dashed lines = prediction.  A colorbar on the right
+    shows ticks at the actual lead times present in the data.
+    """
+    if "lead_time" not in spec_t.dims or len(x_hours) == 0:
+        return
+
+    kvals = spec_t["wavenumber"].values
+    k_max = float(np.nanmax(kvals))
+    pos = kvals[kvals > 0]
+    if len(pos) == 0 or not np.isfinite(k_max) or k_max <= 0:
+        return
+    k_min_pos = float(np.nanmin(pos))
+
+    import matplotlib.cm as _mcm
+    import matplotlib.colors as _mcolors
+
+    n_leads = len(x_hours)
+    _cmap_name = "viridis"
+    cmap = plt.get_cmap(_cmap_name, n_leads)
+    colors = [cmap(i / max(n_leads - 1, 1)) for i in range(n_leads)]
+    # Representative color for the legend: middle of the colormap
+    _mid_color = cmap(0.5)
+
+    fig, ax = plt.subplots(figsize=(10, 6), dpi=dpi * 2)
+    for i, lt in enumerate(spec_t["lead_time"].values):
+        arr_t = spec_t.sel(lead_time=lt).values
+        arr_p = spec_p.sel(lead_time=lt).values
+        ax.loglog(kvals, arr_t, color=colors[i], lw=1.5, alpha=0.85)
+        ax.loglog(kvals, arr_p, color=colors[i], lw=1.5, linestyle="--", alpha=0.85)
+
+    # Legend: target in ground-truth color (solid), prediction in mid colormap hue (dashed)
+    legend_handles = [
+        Line2D([0], [0], color=COLOR_GROUND_TRUTH, lw=1.5, label="Target"),
+        Line2D([0], [0], color=_mid_color, lw=1.5, linestyle="--", label="Prediction"),
+    ]
+    ax.legend(handles=legend_handles, fontsize=9, loc="upper right")
+
+    # Colorbar: each lead gets an equal-width band so ticks are evenly spaced visually.
+    # Use integer indices 0..n_leads-1 as the norm, map to actual hour labels.
+    boundaries = np.arange(-0.5, n_leads, 1.0)
+    norm = _mcolors.BoundaryNorm(boundaries, ncolors=cmap.N)
+    sm = _mcm.ScalarMappable(cmap=cmap, norm=norm)
+    sm.set_array([])
+    cb = fig.colorbar(sm, ax=ax, orientation="vertical", fraction=0.046, pad=0.04)
+    cb.set_label("Lead Time [h]")
+    if n_leads <= 12:
+        tick_indices = list(range(n_leads))
+    else:
+        step = 6 if x_hours[-1] <= 120 else (12 if x_hours[-1] <= 240 else 24)
+        tick_indices = [i for i, h in enumerate(x_hours) if h % step == 0]
+        if not tick_indices:
+            tick_indices = list(range(n_leads))
+    cb.set_ticks(tick_indices)
+    cb.set_ticklabels([f"+{int(x_hours[i])}h" for i in tick_indices])
+
+    ax.set_xlim(k_min_pos, k_max)
+    k_cutoff = k_max / 2.0
+    ax.axvline(k_cutoff, color="gold", linestyle=":", lw=2, alpha=0.8, label="4dx Cutoff")
+    add_wavelength_axis(ax, k_min_pos, k_max)
+    ax.set_xlabel("Zonal Wavenumber (cycles/km)")
+    ax.set_ylabel("Energy Density (weighted)")
+
+    lev_part = format_level_label(level)
+    if init_range and init_range[0] == init_range[1]:
+        init_str = f" ({init_range[0]})"
+    elif init_range:
+        init_str = f" ({init_range[0]}—{init_range[1]})"
+    else:
+        init_str = ""
+    ax.set_title(
+        f"Energy Spectra — {format_variable_name(var)}{lev_part}{init_str}",
+        pad=24,
+        fontsize=10,
+    )
+    ax.grid(True, which="both", ls="--", alpha=0.5)
+    plt.tight_layout()
+
+    fname = build_output_filename(
+        metric="energy_spectra_per_lead",
+        variable=var,
+        level=f"{level}hPa" if level is not None else None,
+        qualifier="overlay",
+        init_time_range=init_range,
+        lead_time_range=lead_range,
+        ensemble=ens_token,
+        ext="png",
+    )
+    save_fig_helper(fig, out_dir / fname, module="energy_spectra")
+    plt.close(fig)
+
+
+def _plot_per_lead_spectra_single(
+    spec_t: xr.DataArray,
+    spec_p: xr.DataArray,
+    var: str,
+    level: int | None,
+    x_hours: np.ndarray,
+    out_dir: Path,
+    init_range: tuple[str, str] | None,
+    ens_token: str | None,
+    dpi: int,
+) -> None:
+    """One PNG per lead_time, all sharing global y-axis limits (GIF-ready).
+
+    The y-axis range is derived from the 4dx-cutoff-trimmed data across *all*
+    lead times so that every frame of a future GIF uses an identical scale.
+    """
+    if "lead_time" not in spec_t.dims or len(x_hours) == 0:
+        return
+
+    kvals = spec_t["wavenumber"].values
+    k_max = float(np.nanmax(kvals))
+    pos = kvals[kvals > 0]
+    if len(pos) == 0 or not np.isfinite(k_max) or k_max <= 0:
+        return
+    k_min_pos = float(np.nanmin(pos))
+    k_cutoff = k_max / 2.0
+    cut_mask = (kvals > 0) & (kvals <= k_cutoff)
+
+    # Global y limits computed across all leads (on the visible wavenumber range)
+    all_vals: list[np.ndarray] = []
+    for lt in spec_t["lead_time"].values:
+        arr_t = spec_t.sel(lead_time=lt).values
+        arr_p = spec_p.sel(lead_time=lt).values
+        mask = cut_mask if np.any(cut_mask) else np.ones(len(kvals), dtype=bool)
+        all_vals.extend([arr_t[mask], arr_p[mask]])
+    all_arr = np.concatenate(all_vals)
+    pos_vals = all_arr[np.isfinite(all_arr) & (all_arr > 0)]
+    if len(pos_vals) == 0:
+        return
+    ymin_global = float(np.nanmin(pos_vals)) * 0.5
+    ymax_global = float(np.nanmax(pos_vals)) * 2.0
+
+    lev_part = format_level_label(level)
+    if init_range and init_range[0] == init_range[1]:
+        init_str = f" ({init_range[0]})"
+    elif init_range:
+        init_str = f" ({init_range[0]}—{init_range[1]})"
+    else:
+        init_str = ""
+
+    for i, lt in enumerate(spec_t["lead_time"].values):
+        h = int(x_hours[i])
+        arr_t = spec_t.sel(lead_time=lt).values
+        arr_p = spec_p.sel(lead_time=lt).values
+
+        lsd_val = float(_compute_lsd_da(spec_t.sel(lead_time=lt), spec_p.sel(lead_time=lt)).values)
+
+        fig, ax = plt.subplots(figsize=(10, 6), dpi=dpi * 2)
+        ax.loglog(kvals, arr_t, color=COLOR_GROUND_TRUTH, label="Target")
+        ax.loglog(kvals, arr_p, color=COLOR_MODEL_PREDICTION, label="Prediction")
+        ax.set_xlim(k_min_pos, k_max)
+        ax.set_ylim(ymin_global, ymax_global)
+        ax.axvline(k_cutoff, color="gold", linestyle=":", lw=2, alpha=0.8, label="4dx Cutoff")
+        add_wavelength_axis(ax, k_min_pos, k_max)
+
+        props = {"boxstyle": "round", "facecolor": "wheat", "alpha": 0.5}
+        ax.text(
+            0.5,
+            0.05,
+            f"LSD = {lsd_val:.4f}",
+            transform=ax.transAxes,
+            ha="center",
+            va="bottom",
+            bbox=props,
+        )
+        ax.set_xlabel("Zonal Wavenumber (cycles/km)")
+        ax.set_ylabel("Energy Density (weighted)")
+        ax.set_title(
+            f"Energy Spectra — {format_variable_name(var)}{lev_part}{init_str} (+{h:03d}h)",
+            pad=24,
+            fontsize=10,
+        )
+        ax.legend(fontsize=10)
+        ax.grid(True, which="both", ls="--", alpha=0.5)
+        plt.tight_layout()
+
+        fname = build_output_filename(
+            metric="energy_spectrum",
+            variable=var,
+            level=f"{level}hPa" if level is not None else None,
+            qualifier=f"lead{h:03d}h",
+            init_time_range=init_range,
+            lead_time_range=None,
+            ensemble=ens_token,
+            ext="png",
+        )
+        save_fig_helper(fig, out_dir / fname, module="energy_spectra")
+        plt.close(fig)
+
+
 def run(
     ds_target: xr.Dataset,
     ds_prediction: xr.Dataset,
@@ -831,6 +1037,7 @@ def run(
     # individual spectrum PNGs and NPZ files are suppressed.  CSVs and
     # spectrograms are always written regardless of this flag.
     individual_plots = bool(es_cfg.get("individual_plots", False))
+    per_lead_layout = str(es_cfg.get("per_lead_spectra_layout", "none")).lower()
 
     # Preserve full datasets for metrics
     ds_target_full = ds_target
@@ -1812,6 +2019,33 @@ def run(
                 save_fig_helper(fig, out_tripanel, module="energy_spectra")
                 plt.close(fig)
 
+            # ── Per-lead energy spectrum plots (overlay and/or single) ──
+            if save_plot and per_lead_layout in ("overlay", "both"):
+                _plot_per_lead_spectra_overlay(
+                    spec_t2,
+                    spec_p2,
+                    str(var),
+                    None,
+                    x_hours,
+                    section_output,
+                    init_range,
+                    lead_range,
+                    ens_token,
+                    dpi,
+                )
+            if save_plot and per_lead_layout in ("single", "both"):
+                _plot_per_lead_spectra_single(
+                    spec_t2,
+                    spec_p2,
+                    str(var),
+                    None,
+                    x_hours,
+                    section_output,
+                    init_range,
+                    ens_token,
+                    dpi,
+                )
+
         # 3D per-level spectrograms and bundle NPZs
         # Always compute spectra and save NPZ bundles so the intercomparison
         # pipeline can produce 3D spectrograms / band plots.  Only gate the
@@ -1922,6 +2156,33 @@ def run(
                                 )
                     except Exception:
                         pass
+
+                    # ── Per-lead energy spectrum plots for this 3D level ──
+                    if save_plot and per_lead_layout in ("overlay", "both"):
+                        _plot_per_lead_spectra_overlay(
+                            spec_t3,
+                            spec_p3,
+                            str(var),
+                            int(lvl),
+                            x_hours_3d,
+                            section_output,
+                            init_range,
+                            lead_range,
+                            ens_token,
+                            dpi,
+                        )
+                    if save_plot and per_lead_layout in ("single", "both"):
+                        _plot_per_lead_spectra_single(
+                            spec_t3,
+                            spec_p3,
+                            str(var),
+                            int(lvl),
+                            x_hours_3d,
+                            section_output,
+                            init_range,
+                            ens_token,
+                            dpi,
+                        )
 
                     # Apply 4Δx wavenumber cutoff for plotting (same as 2D)
                     _k_max_3d = float(np.nanmax(kvals_3d))

--- a/src/swissclim_evaluations/plots/energy_spectra.py
+++ b/src/swissclim_evaluations/plots/energy_spectra.py
@@ -316,22 +316,29 @@ def _plot_single_spectrum(
     save_plot_data: bool,
     save_figure: bool,
     date_str: str = "",
+    show_4dx_cutoff: bool = True,
+    show_lsd: bool = True,
 ):
     """Create one spectrum comparison figure & optional NPZ."""
     fig, ax = plt.subplots(figsize=(10, 6), dpi=dpi * 2)
     ax.loglog(wavenumber, arr_target, color=COLOR_GROUND_TRUTH, label="Target")
     ax.loglog(wavenumber, arr_pred, color=COLOR_MODEL_PREDICTION, label="Prediction")
 
-    props = {"boxstyle": "round", "facecolor": "wheat", "alpha": 0.5}  # dict literal (ruff C408)
-    ax.text(
-        0.5,
-        0.05,
-        f"LSD = {lsd_val:.4f}",
-        transform=ax.transAxes,
-        ha="center",
-        va="bottom",
-        bbox=props,
-    )
+    if show_lsd:
+        props = {
+            "boxstyle": "round",
+            "facecolor": "wheat",
+            "alpha": 0.5,
+        }  # dict literal (ruff C408)
+        ax.text(
+            0.5,
+            0.05,
+            f"LSD = {lsd_val:.4f}",
+            transform=ax.transAxes,
+            ha="center",
+            va="bottom",
+            bbox=props,
+        )
     ax.set_xlabel("Zonal Wavenumber (cycles/km)")
     ax.set_ylabel("Energy Density (weighted)")
     # --- Top axis wavelength (km) -------------------------------------------------
@@ -347,8 +354,11 @@ def _plot_single_spectrum(
     ax.set_xlim(k_min, k_max)
 
     # Add golden dotted line at 4*dx cutoff (k_max / 2)
-    k_cutoff = k_max / 2.0
-    ax.axvline(k_cutoff, color="gold", linestyle=":", linewidth=2, alpha=0.8, label="4dx Cutoff")
+    if show_4dx_cutoff:
+        k_cutoff = k_max / 2.0
+        ax.axvline(
+            k_cutoff, color="gold", linestyle=":", linewidth=2, alpha=0.8, label="4dx Cutoff"
+        )
 
     add_wavelength_axis(ax, k_min, k_max)
 
@@ -442,6 +452,8 @@ def _plot_energy_spectra(
     override_ensemble_token: str | None = None,
     performance_cfg: dict[str, Any] | None = None,
     weights: xr.DataArray | None = None,
+    show_4dx_cutoff: bool = True,
+    show_lsd: bool = True,
 ) -> xr.DataArray:
     """Generate ONE spectrum & LSD per (init_time, lead_time) combination (no temporal averaging).
 
@@ -516,6 +528,8 @@ def _plot_energy_spectra(
             save_plot_data,
             save_figure,
             date_str=date_str,
+            show_4dx_cutoff=show_4dx_cutoff,
+            show_lsd=show_lsd,
         )
         return lsd_da
 
@@ -642,6 +656,8 @@ def _plot_energy_spectra(
                 save_plot_data,
                 save_figure,
                 date_str=job.get("date_str", ""),
+                show_4dx_cutoff=show_4dx_cutoff,
+                show_lsd=show_lsd,
             )
             # Clear large arrays from memory
             job["arr_t"] = None
@@ -688,6 +704,8 @@ def _plot_averaged_spectra(
     dpi: int,
     save_plot_data: bool,
     save_figure: bool,
+    show_4dx_cutoff: bool = True,
+    show_lsd: bool = True,
 ) -> None:
     """Plot spectra averaged over init_time.
 
@@ -753,6 +771,8 @@ def _plot_averaged_spectra(
                 dpi=dpi,
                 save_plot_data=save_plot_data,
                 save_figure=save_figure,
+                show_4dx_cutoff=show_4dx_cutoff,
+                show_lsd=show_lsd,
             )
     else:
         # No lead time dim (scalar or missing)
@@ -783,6 +803,8 @@ def _plot_averaged_spectra(
             dpi=dpi,
             save_plot_data=save_plot_data,
             save_figure=save_figure,
+            show_4dx_cutoff=show_4dx_cutoff,
+            show_lsd=show_lsd,
         )
 
 
@@ -797,6 +819,7 @@ def _plot_per_lead_spectra_overlay(
     lead_range: tuple[str, str] | None,
     ens_token: str | None,
     dpi: int,
+    show_4dx_cutoff: bool = True,
 ) -> None:
     """One PNG with one colored line per lead_time for both target and prediction.
 
@@ -857,8 +880,9 @@ def _plot_per_lead_spectra_overlay(
     cb.set_ticklabels([f"+{int(x_hours[i])}h" for i in tick_indices])
 
     ax.set_xlim(k_min_pos, k_max)
-    k_cutoff = k_max / 2.0
-    ax.axvline(k_cutoff, color="gold", linestyle=":", lw=2, alpha=0.8, label="4dx Cutoff")
+    if show_4dx_cutoff:
+        k_cutoff = k_max / 2.0
+        ax.axvline(k_cutoff, color="gold", linestyle=":", lw=2, alpha=0.8, label="4dx Cutoff")
     add_wavelength_axis(ax, k_min_pos, k_max)
     ax.set_xlabel("Zonal Wavenumber (cycles/km)")
     ax.set_ylabel("Energy Density (weighted)")
@@ -902,6 +926,8 @@ def _plot_per_lead_spectra_single(
     init_range: tuple[str, str] | None,
     ens_token: str | None,
     dpi: int,
+    show_4dx_cutoff: bool = True,
+    show_lsd: bool = True,
 ) -> None:
     """One PNG per lead_time, all sharing global y-axis limits (GIF-ready).
 
@@ -954,19 +980,21 @@ def _plot_per_lead_spectra_single(
         ax.loglog(kvals, arr_p, color=COLOR_MODEL_PREDICTION, label="Prediction")
         ax.set_xlim(k_min_pos, k_max)
         ax.set_ylim(ymin_global, ymax_global)
-        ax.axvline(k_cutoff, color="gold", linestyle=":", lw=2, alpha=0.8, label="4dx Cutoff")
+        if show_4dx_cutoff:
+            ax.axvline(k_cutoff, color="gold", linestyle=":", lw=2, alpha=0.8, label="4dx Cutoff")
         add_wavelength_axis(ax, k_min_pos, k_max)
 
-        props = {"boxstyle": "round", "facecolor": "wheat", "alpha": 0.5}
-        ax.text(
-            0.5,
-            0.05,
-            f"LSD = {lsd_val:.4f}",
-            transform=ax.transAxes,
-            ha="center",
-            va="bottom",
-            bbox=props,
-        )
+        if show_lsd:
+            props = {"boxstyle": "round", "facecolor": "wheat", "alpha": 0.5}
+            ax.text(
+                0.5,
+                0.05,
+                f"LSD = {lsd_val:.4f}",
+                transform=ax.transAxes,
+                ha="center",
+                va="bottom",
+                bbox=props,
+            )
         ax.set_xlabel("Zonal Wavenumber (cycles/km)")
         ax.set_ylabel("Energy Density (weighted)")
         ax.set_title(
@@ -1038,6 +1066,8 @@ def run(
     # spectrograms are always written regardless of this flag.
     individual_plots = bool(es_cfg.get("individual_plots", False))
     per_lead_layout = str(es_cfg.get("per_lead_spectra_layout", "none")).lower()
+    show_4dx_cutoff = bool(es_cfg.get("show_4dx_cutoff", True))
+    show_lsd = bool(es_cfg.get("show_lsd", True))
 
     # Preserve full datasets for metrics
     ds_target_full = ds_target
@@ -1247,6 +1277,8 @@ def run(
                     dpi,
                     save_plot_data=save_npz,
                     save_figure=save_plot,
+                    show_4dx_cutoff=show_4dx_cutoff,
+                    show_lsd=show_lsd,
                 )
 
             # Compute banded LSD metrics (2D)
@@ -1342,6 +1374,8 @@ def run(
                     override_ensemble_token=curr_ens_token,
                     performance_cfg=perf_cfg,
                     weights=weights,
+                    show_4dx_cutoff=show_4dx_cutoff,
+                    show_lsd=show_lsd,
                 )
 
     # 3D variables (per-level)
@@ -1482,6 +1516,8 @@ def run(
                         dpi,
                         save_plot_data=save_npz,
                         save_figure=save_plot,
+                        show_4dx_cutoff=show_4dx_cutoff,
+                        show_lsd=show_lsd,
                     )
 
         if report_per_level and lsd_3d_rows:
@@ -1581,6 +1617,8 @@ def run(
                             save_figure=save_plot,
                             override_ensemble_token=curr_ens_token,
                             weights=weights,
+                            show_4dx_cutoff=show_4dx_cutoff,
+                            show_lsd=show_lsd,
                         )
 
     # Optional: per-member NPZ spectrum exports when requested
@@ -1611,6 +1649,8 @@ def run(
                     save_figure=False,
                     override_ensemble_token=token,
                     performance_cfg=perf_cfg,
+                    show_4dx_cutoff=show_4dx_cutoff,
+                    show_lsd=show_lsd,
                 )
 
     # Optional: spectrogram over lead_time (x) and wavenumber (y) with energy color
@@ -2032,6 +2072,7 @@ def run(
                     lead_range,
                     ens_token,
                     dpi,
+                    show_4dx_cutoff=show_4dx_cutoff,
                 )
             if save_plot and per_lead_layout in ("single", "both"):
                 _plot_per_lead_spectra_single(
@@ -2044,6 +2085,8 @@ def run(
                     init_range,
                     ens_token,
                     dpi,
+                    show_4dx_cutoff=show_4dx_cutoff,
+                    show_lsd=show_lsd,
                 )
 
         # 3D per-level spectrograms and bundle NPZs
@@ -2170,6 +2213,7 @@ def run(
                             lead_range,
                             ens_token,
                             dpi,
+                            show_4dx_cutoff=show_4dx_cutoff,
                         )
                     if save_plot and per_lead_layout in ("single", "both"):
                         _plot_per_lead_spectra_single(
@@ -2182,6 +2226,8 @@ def run(
                             init_range,
                             ens_token,
                             dpi,
+                            show_4dx_cutoff=show_4dx_cutoff,
+                            show_lsd=show_lsd,
                         )
 
                     # Apply 4Δx wavenumber cutoff for plotting (same as 2D)


### PR DESCRIPTION
This pull request introduces support for new per-lead energy spectrum plots in the energy spectra evaluation pipeline, configurable via the `per_lead_spectra_layout` option. It adds two new plotting modes - overlay and single, for both 2D and 3D variables, updates documentation, and exposes configuration in the example YAML.

closes #115 